### PR TITLE
Add work-around and fixes for blocked SIGCHLD environments

### DIFF
--- a/geopmdpy/geopmdpy/__main__.py
+++ b/geopmdpy/geopmdpy/__main__.py
@@ -53,8 +53,11 @@ def main_dbus():
         try:
             if not os.path.exists('/dev/cpu/msr_batch'):
                 writer.backup_and_try_update('on\n')
+            try:
+                os.unlink('/run/geopm/geopm-topo-cache')
+            except (FileNotFoundError, PermissionError):
+                pass
             _service = service.GEOPMService()
-            _service.topo_rm_cache()
             _bus.publish_object("/io/github/geopm", _service)
             _bus.register_service("io.github.geopm")
             _loop.run()

--- a/geopmdpy/geopmdpy/pio.py
+++ b/geopmdpy/geopmdpy/pio.py
@@ -9,6 +9,7 @@ signals and writing controls from system components.
 
 """
 
+import sys
 
 from . import gffi
 from . import topo
@@ -130,10 +131,13 @@ def read_signal(signal_name, domain_type, domain_idx):
         float: The value of the signal read in SI units.
 
     """
+    sys.stderr.write("DEBUGGING geopmdpy: pio.read_signal called with signal_name={}, domain_type={}, domain_idx={}\n".format(signal_name, domain_type, domain_idx))
     result_cdbl = gffi.gffi.new("double*")
     signal_name_cstr = gffi.gffi.new("char[]", signal_name.encode())
     domain_type = topo.domain_type(domain_type)
+    sys.stderr.write("DEBUGGING geopmdpy: About to call geopm_pio_read_signal()...\n")
     err = gffi.dl_geopmd.geopm_pio_read_signal(signal_name_cstr, domain_type, domain_idx, result_cdbl)
+    sys.stderr.write("DEBUGGING geopmdpy: Back from call to geopm_pio_read_signal().\n")
     if err < 0:
         raise RuntimeError('geopm_pio_read_signal() failed: {}'.format(error.message(err)))
     return result_cdbl[0]

--- a/integration/service/open_pbs/README.rst
+++ b/integration/service/open_pbs/README.rst
@@ -272,17 +272,17 @@ The hooks to enforce node power caps are available in the GEOPM
 ``integration/service/open_pbs`` directory and are split into two files:
 
 1. ``geopm_power_limit_compute.py`` - Contains prologue and epilogue hooks that need to be installed on compute nodes
-2. ``geopm_power_limit_server.py`` - Contains the queuejob hook that needs to be installed on the PBS server
+2. ``geopm_power_limit_server.py`` - Contains the queuejob and modifyjob hooks that need to be installed on the PBS server
 
 These can be installed with the following commands:
 
-For the queuejob hook on the PBS server:
+For the queuejob and modifyjob hooks on the PBS server:
 
 ::
 
    qmgr -c "create hook geopm_power_limit_server"
    qmgr -c "import hook geopm_power_limit_server application/x-python default geopm_power_limit_server.py"
-   qmgr -c "set hook geopm_power_limit_server event='queuejob'"
+   qmgr -c "set hook geopm_power_limit_server event='queuejob,modifyjob'"
 
 For the prologue and epilogue hooks on compute nodes:
 
@@ -292,8 +292,8 @@ For the prologue and epilogue hooks on compute nodes:
    qmgr -c "import hook geopm_power_limit_compute application/x-python default geopm_power_limit_compute.py"
    qmgr -c "set hook geopm_power_limit_compute event='execjob_prologue,execjob_epilogue'"
 
-Note how the hooks need to be configured to run in three events: job prologue,
-job epilogue, and queuejob, but on different parts of the system. The purpose of each hook is illustrated
+Note how the hooks need to be configured to run in four events: job prologue,
+job epilogue, queuejob, and modifyjob, but on different parts of the system. The purpose of each hook is illustrated
 in the job submission timeline below.
 
 .. code:: mermaid

--- a/integration/service/open_pbs/README.rst
+++ b/integration/service/open_pbs/README.rst
@@ -236,9 +236,17 @@ The GEOPM power limit hooks require:
 
 Installation
 ------------
-Prior to being able to use the power limit feature, the
-``geopm-node-power-limit`` and ``geopm-job-power-limit`` resources and the
-power limit hook need to be installed on the OpenPBS server.
+The GEOPM power limiting functionality uses two separate hooks that need to be installed in different places:
+
+1. The server hook (``geopm_power_limit_server.py``) needs to be installed on the PBS server
+2. The compute hook (``geopm_power_limit_compute.py``) needs to be installed on all compute nodes
+
+Two installation scripts are provided to simplify the installation process:
+
+1. ``geopm_install_pbs_power_limit_server.sh`` - Installs the server-side hook and resources
+2. ``geopm_install_pbs_power_limit_compute.sh`` - Installs the compute-node hook
+
+Prior to being able to use the power limit feature, you need to run these scripts on the respective systems.
 
 The resources can be created with the following commands:
 
@@ -311,5 +319,5 @@ submission timeline below.
     classDef event fill:#dde9af
     classDef hook fill:#4472c4,color:#fff
 
-For convenience, a script is provided to perform these installation commands:
-``geopm_install_pbs_power_limit.sh``
+For convenience, two scripts are provided to perform these installation commands:
+``geopm_install_pbs_power_limit_server.sh`` and ``geopm_install_pbs_power_limit_compute.sh``

--- a/integration/service/open_pbs/README.rst
+++ b/integration/service/open_pbs/README.rst
@@ -268,31 +268,43 @@ Restart the PBS scheduler for the configuration changes to take effect. For
 example, one way is to use systemctl or run ``/etc/init.d/pbs restart`` where
 the PBS scheduler is running.
 
-The hook to enforce node power caps is available in the GEOPM
-``integration/service/open_pbs`` directory (``geopm_power_limit.py``) and
-can be installed with the following commands:
+The hooks to enforce node power caps are available in the GEOPM
+``integration/service/open_pbs`` directory and are split into two files:
 
+1. ``geopm_power_limit_compute.py`` - Contains prologue and epilogue hooks that need to be installed on compute nodes
+2. ``geopm_power_limit_server.py`` - Contains the queuejob hook that needs to be installed on the PBS server
+
+These can be installed with the following commands:
+
+For the prologue and epilogue hooks on compute nodes:
 ::
 
    qmgr -c "create hook geopm_power_limit"
-   qmgr -c "import hook geopm_power_limit application/x-python default geopm_power_limit.py"
-   qmgr -c "set hook geopm_power_limit event='execjob_prologue,execjob_epilogue,queuejob'"
+   qmgr -c "import hook geopm_power_limit application/x-python default geopm_power_limit_compute.py"
+   qmgr -c "set hook geopm_power_limit event='execjob_prologue,execjob_epilogue'"
 
-Note how the hook needs to be configured to run in three events: job prologue,
-job epilogue, queuejob. The purpose of each hook is illustrated in the job
+For the queuejob hook on the PBS server:
+::
+
+   qmgr -c "create hook geopm_power_limit_queuejob"
+   qmgr -c "import hook geopm_power_limit_queuejob application/x-python default geopm_power_limit_server.py"
+   qmgr -c "set hook geopm_power_limit_queuejob event='queuejob'"
+
+Note how the hooks need to be configured to run in three events: job prologue,
+job epilogue, and queuejob, but on different parts of the system. The purpose of each hook is illustrated in the job
 submission timeline below.
 
 .. code:: mermaid
 
   flowchart TD
     submit["User submits job"]
-    queuejob["<b>queuejob hook</b>
+    queuejob["<b>queuejob hook (server)</b>
       Set job's power to minimum power that meets slowdown requirements"]
     start["Job Starts"]
-    prologue["<b>execjob_prologue hook</b>
+    prologue["<b>execjob_prologue hook (compute)</b>
       Save current node power limits and set new limits equal to the job's allocated power per node"]
     finish["Job Finishes"]
-    epilogue["<b>execjob_epilogue hook</b>
+    epilogue["<b>execjob_epilogue hook (compute)</b>
       Restore saved power limits."]
 
     submit:::event-->queuejob:::hook-->start:::event-->prologue:::hook-->finish:::event-->epilogue:::hook

--- a/integration/service/open_pbs/README.rst
+++ b/integration/service/open_pbs/README.rst
@@ -228,7 +228,7 @@ Requirements
 The GEOPM power limit hooks require:
 
 - OpenPBS
-- geopmdpy (and libgeopmd) on nodes where the power limit feature is needed
+- geopmdpy (and libgeopmd) on nodes where the power limit feature is needed (compute hook only)
 - This feature requires platform vendor HW support. In particular, it requires
   HW support for the ``MSR::PLATFORM_POWER_LIMIT`` MSRs (``PL1_POWER_LIMIT``,
   ``PL1_TIME_WINDOW``, ``PL1_CLAMP_ENABLE``, ``PL1_LIMIT_ENABLE``), and the
@@ -236,17 +236,9 @@ The GEOPM power limit hooks require:
 
 Installation
 ------------
-The GEOPM power limiting functionality uses two separate hooks that need to be installed in different places:
-
-1. The server hook (``geopm_power_limit_server.py``) needs to be installed on the PBS server
-2. The compute hook (``geopm_power_limit_compute.py``) needs to be installed on all compute nodes
-
-Two installation scripts are provided to simplify the installation process:
-
-1. ``geopm_install_pbs_power_limit_server.sh`` - Installs the server-side hook and resources
-2. ``geopm_install_pbs_power_limit_compute.sh`` - Installs the compute-node hook
-
-Prior to being able to use the power limit feature, you need to run these scripts on the respective systems.
+Prior to being able to use the power limit feature, the
+``geopm-node-power-limit`` and ``geopm-job-power-limit`` resources and the
+power limit hook need to be installed on the OpenPBS server.
 
 The resources can be created with the following commands:
 
@@ -284,23 +276,25 @@ The hooks to enforce node power caps are available in the GEOPM
 
 These can be installed with the following commands:
 
-For the prologue and epilogue hooks on compute nodes:
-::
-
-   qmgr -c "create hook geopm_power_limit"
-   qmgr -c "import hook geopm_power_limit application/x-python default geopm_power_limit_compute.py"
-   qmgr -c "set hook geopm_power_limit event='execjob_prologue,execjob_epilogue'"
-
 For the queuejob hook on the PBS server:
+
 ::
 
-   qmgr -c "create hook geopm_power_limit_queuejob"
-   qmgr -c "import hook geopm_power_limit_queuejob application/x-python default geopm_power_limit_server.py"
-   qmgr -c "set hook geopm_power_limit_queuejob event='queuejob'"
+   qmgr -c "create hook geopm_power_limit_server"
+   qmgr -c "import hook geopm_power_limit_server application/x-python default geopm_power_limit_server.py"
+   qmgr -c "set hook geopm_power_limit_server event='queuejob'"
+
+For the prologue and epilogue hooks on compute nodes:
+
+::
+
+   qmgr -c "create hook geopm_power_limit_compute"
+   qmgr -c "import hook geopm_power_limit_compute application/x-python default geopm_power_limit_compute.py"
+   qmgr -c "set hook geopm_power_limit_compute event='execjob_prologue,execjob_epilogue'"
 
 Note how the hooks need to be configured to run in three events: job prologue,
-job epilogue, and queuejob, but on different parts of the system. The purpose of each hook is illustrated in the job
-submission timeline below.
+job epilogue, and queuejob, but on different parts of the system. The purpose of each hook is illustrated
+in the job submission timeline below.
 
 .. code:: mermaid
 
@@ -319,5 +313,5 @@ submission timeline below.
     classDef event fill:#dde9af
     classDef hook fill:#4472c4,color:#fff
 
-For convenience, two scripts are provided to perform these installation commands:
+For convenience, two scripts are provided to perform these installation commands on their respective targets:
 ``geopm_install_pbs_power_limit_server.sh`` and ``geopm_install_pbs_power_limit_compute.sh``

--- a/integration/service/open_pbs/TestPowerLimitHook.py
+++ b/integration/service/open_pbs/TestPowerLimitHook.py
@@ -143,6 +143,25 @@ class TestPowerLimitPrologue(unittest.TestCase):
         self._mock_event.accept.assert_called_once()
         self._mock_event.reject.assert_not_called()
 
+    def test_power_limit_request_zero(self, mock_secure_make_dirs,
+                                 mock_write_control, mock_read_signal):
+        REQUESTED_POWER_LIMIT = 0
+
+        self._mock_server_job.Resource_List = {
+            compute_hook._POWER_LIMIT_RESOURCE: REQUESTED_POWER_LIMIT,
+        }
+
+        compute_hook.do_power_limit_prologue()
+
+        # Assert prologue gets the right server job
+        self._mock_server.job.assert_called_with(self.JOB_ID)
+        # Hook returns when bool(limit) == False
+        mock_secure_make_dirs.assert_not_called()
+        mock_write_control.assert_not_called()
+        # Assert hook accepts event
+        self._mock_event.accept.assert_called_once()
+        self._mock_event.reject.assert_not_called()
+
     def test_invalid_power_limit(self, mock_secure_make_dirs,
                                  mock_write_control, mock_read_signal):
         REQUESTED_POWER_LIMIT = "not a number"
@@ -598,6 +617,66 @@ class TestPowerLimitQueuejob(unittest.TestCase):
         self.assertEqual(self._mock_event_job.Resource_List[server_hook._JOB_POWER_LIMIT_RESOURCE],
                          self._MAX_NODE_POWER_LIMIT * .5)
 
+
+class TestPowerLimitModifyjob(unittest.TestCase):
+    def setUp(self):
+        self._mock_pbs = server_hook.pbs
+        self._mock_server = mock.Mock()
+        self._mock_event = mock.Mock()
+        self._mock_event_job = mock.Mock()
+        self._mock_event_job_o = mock.Mock()
+
+        self._mock_pbs.server.return_value = self._mock_server
+        self._mock_pbs.event.return_value = self._mock_event
+        self._mock_event.job = self._mock_event_job
+        self._mock_event.job_o = self._mock_event_job_o
+
+        self._mock_event_job.Resource_List = {
+            server_hook._JOB_POWER_LIMIT_RESOURCE: None,
+            server_hook._POWER_LIMIT_RESOURCE: None,
+            server_hook._DEFAULT_SLOWDOWN_RESOURCE: None,
+            server_hook._JOB_TYPE_RESOURCE: None,
+        }
+        self._mock_event_job_o.Resource_List = {
+            server_hook._JOB_POWER_LIMIT_RESOURCE: None,
+            server_hook._POWER_LIMIT_RESOURCE: None,
+            server_hook._DEFAULT_SLOWDOWN_RESOURCE: None,
+            server_hook._JOB_TYPE_RESOURCE: None,
+        }
+
+        self._mock_server.resources_available = {
+            server_hook._JOB_POWER_LIMIT_RESOURCE: None,
+            server_hook._MAX_POWER_LIMIT_RESOURCE: None,
+            server_hook._MIN_POWER_LIMIT_RESOURCE: None,
+        }
+
+    def test_modifyjob_with_new_power_limit(self):
+        NEW_POWER_LIMIT = 600
+        self._mock_event_job.Resource_List[server_hook._POWER_LIMIT_RESOURCE] = NEW_POWER_LIMIT
+
+        server_hook.do_power_limit_modifyjob()
+
+        # Assert the new power limit is retained
+        self.assertEqual(self._mock_event_job.Resource_List[server_hook._POWER_LIMIT_RESOURCE], NEW_POWER_LIMIT)
+
+    def test_modifyjob_without_new_power_limit(self):
+        self._mock_event_job_o.Resource_List[server_hook._POWER_LIMIT_RESOURCE] = 500
+
+        # Emulate PBS logic
+        self._mock_event_job.Resource_List = copy.deepcopy(self._mock_event_job_o.Resource_List)
+
+        server_hook.do_power_limit_modifyjob()
+
+        # Assert the original power limit is retained
+        self.assertEqual(self._mock_event_job.Resource_List[server_hook._POWER_LIMIT_RESOURCE], 500)
+
+    def test_modifyjob_with_no_original_power_limit(self):
+        self._mock_event_job_o.Resource_List[server_hook._POWER_LIMIT_RESOURCE] = None
+
+        server_hook.do_power_limit_modifyjob()
+
+        # Assert no power limit is set
+        self.assertIsNone(self._mock_event_job.Resource_List[server_hook._POWER_LIMIT_RESOURCE])
 
 
 if __name__ == "__main__":

--- a/integration/service/open_pbs/TestPowerLimitHook.py
+++ b/integration/service/open_pbs/TestPowerLimitHook.py
@@ -10,6 +10,8 @@ from unittest import mock
 import json
 import os
 import copy
+import tempfile
+import shutil
 
 mock.patch.dict("sys.modules", pbs=mock.MagicMock()).start()
 mock.patch("cffi.FFI.dlopen").start()
@@ -18,6 +20,7 @@ import geopm_power_limit_server as server_hook
 
 
 SAVED_CONTROLS_FILE = "saved_controls.json"
+RESOURCE_TMP_DIR = tempfile.mkdtemp(prefix='geopm_test_resources_')
 
 CURRENT_SETTINGS = [
         {"name": "MSR::PLATFORM_POWER_LIMIT:PL1_TIME_WINDOW",
@@ -42,6 +45,16 @@ CURRENT_SETTINGS_REF = {
         d["name"]: {k: v for (k, v) in d.items() if k != "name"}
         for d in CURRENT_SETTINGS
     }
+
+def resource_file_path(job_id):
+    return os.path.join(RESOURCE_TMP_DIR, f"{job_id}.resources")
+
+
+def write_resource_file(job_id, resource_kv):
+    # resource_kv: dict of {name: value}; values written verbatim
+    parts = [f"{k}={'' if v is None else v}" for k, v in resource_kv.items()]
+    with open(resource_file_path(job_id), 'w') as f:
+        f.write(';'.join(parts))
 
 
 def read_signal(name, domain_type, domain_idx):
@@ -68,6 +81,12 @@ def write_settings_to_file(file_name, settings):
 
 def setUpModule():
     compute_hook._SAVED_CONTROLS_FILE = SAVED_CONTROLS_FILE
+    compute_hook._RESOURCE_FILE_SEARCH_PATH = RESOURCE_TMP_DIR
+
+
+def tearDownModule():
+    shutil.rmtree(RESOURCE_TMP_DIR, ignore_errors=True)
+
 
 class MockAttr():
     def __init__(self, value):
@@ -87,32 +106,31 @@ class MockAttr():
 @mock.patch("geopmdpy.system_files.secure_make_dirs")
 class TestPowerLimitPrologue(unittest.TestCase):
     JOB_ID = 1
+    HOOK_CONFIG_PATH = 'fake/file/path'
 
     def setUp(self):
-        self._mock_pbs = server_hook.pbs
+        self._mock_pbs = compute_hook.pbs
         self._mock_event = mock.Mock()
-        self._mock_server = mock.Mock()
-        self._mock_server_job = mock.Mock()
-
-        self._mock_pbs.event.return_value = self._mock_event
-        self._mock_pbs.server.return_value = self._mock_server
-        self._mock_server.job.return_value = self._mock_server_job
-
+        self._mock_pbs.event.return_value = self._mock_event  # Only first call should occur in hook code
         self._mock_event.job.id = self.JOB_ID
+        self._mock_pbs.hook_config_filename = self.HOOK_CONFIG_PATH
 
     def tearDown(self):
         try:
             os.unlink(SAVED_CONTROLS_FILE)
         except:
             pass
+        try:
+            os.unlink(resource_file_path(self.JOB_ID))
+        except:
+            pass
 
     def test_power_limit_request(self, mock_secure_make_dirs,
                                  mock_write_control, mock_read_signal):
         REQUESTED_POWER_LIMIT = 240000000
-
-        self._mock_server_job.Resource_List = {
-            compute_hook._POWER_LIMIT_RESOURCE: REQUESTED_POWER_LIMIT,
-        }
+        write_resource_file(self.JOB_ID, {
+            compute_hook._POWER_LIMIT_RESOURCE: REQUESTED_POWER_LIMIT
+        })
 
         # Prepare expectations
         new_settings = copy.deepcopy(compute_hook._controls)
@@ -127,10 +145,8 @@ class TestPowerLimitPrologue(unittest.TestCase):
                                         power_limit_setting["domain_idx"],
                                         power_limit_setting["setting"]))
 
-        compute_hook.do_power_limit_prologue()
+        compute_hook.do_power_limit_prologue(self._mock_event)
 
-        # Assert prologue gets the right server job
-        self._mock_server.job.assert_called_with(self.JOB_ID)
         # Assert saved controls path is created securely
         mock_secure_make_dirs.assert_called_with(compute_hook._SAVED_CONTROLS_PATH)
         # Assert settings are saved to file
@@ -144,17 +160,14 @@ class TestPowerLimitPrologue(unittest.TestCase):
         self._mock_event.reject.assert_not_called()
 
     def test_power_limit_request_zero(self, mock_secure_make_dirs,
-                                 mock_write_control, mock_read_signal):
+                                      mock_write_control, mock_read_signal):
         REQUESTED_POWER_LIMIT = 0
+        write_resource_file(self.JOB_ID, {
+            compute_hook._POWER_LIMIT_RESOURCE: REQUESTED_POWER_LIMIT
+        })
 
-        self._mock_server_job.Resource_List = {
-            compute_hook._POWER_LIMIT_RESOURCE: REQUESTED_POWER_LIMIT,
-        }
+        compute_hook.do_power_limit_prologue(self._mock_event)
 
-        compute_hook.do_power_limit_prologue()
-
-        # Assert prologue gets the right server job
-        self._mock_server.job.assert_called_with(self.JOB_ID)
         # Hook returns when bool(limit) == False
         mock_secure_make_dirs.assert_not_called()
         mock_write_control.assert_not_called()
@@ -164,16 +177,15 @@ class TestPowerLimitPrologue(unittest.TestCase):
 
     def test_invalid_power_limit(self, mock_secure_make_dirs,
                                  mock_write_control, mock_read_signal):
-        REQUESTED_POWER_LIMIT = "not a number"
-
-        self._mock_server_job.Resource_List = {
-                compute_hook._POWER_LIMIT_RESOURCE: REQUESTED_POWER_LIMIT}
+        write_resource_file(self.JOB_ID, {
+            compute_hook._POWER_LIMIT_RESOURCE: "not_a_number"
+        })
         self._mock_pbs.EXECJOB_PROLOGUE = 'execjob_prologue_event_type'
         self._mock_event.type = self._mock_pbs.EXECJOB_PROLOGUE
         self._mock_event.reject.side_effect = RuntimeError
 
         with self.assertRaises(RuntimeError):
-            compute_hook.do_power_limit_prologue()
+            compute_hook.do_power_limit_prologue(self._mock_event)
 
         # Assert job gets removed from queue upon failure
         self._mock_event.job.delete.assert_called_once()
@@ -186,9 +198,9 @@ class TestPowerLimitPrologue(unittest.TestCase):
 
     def test_event_without_power_limit(self, mock_secure_make_dirs,
                                        mock_write_control, mock_read_signal):
-        self._mock_server_job.Resource_List = {}
+        write_resource_file(self.JOB_ID, {})
 
-        compute_hook.do_power_limit_prologue()
+        compute_hook.do_power_limit_prologue(self._mock_event)
 
         # Assert hook accepts the event
         self._mock_event.accept.assert_called_once()
@@ -199,7 +211,7 @@ class TestPowerLimitPrologue(unittest.TestCase):
 
     def test_power_settings_restored(self, mock_secure_make_dirs,
                                      mock_write_control, mock_read_signal):
-        self._mock_server_job.Resource_List = {}
+        write_resource_file(self.JOB_ID, {})
 
         # Simulate epilogue not being able to run and settings from prior job
         # still in place.
@@ -209,7 +221,7 @@ class TestPowerLimitPrologue(unittest.TestCase):
         # execution. Using an exception here to simulate the same side effect.
         self._mock_event.accept.side_effect = RuntimeError
         with self.assertRaises(RuntimeError):
-            compute_hook.do_power_limit_prologue()
+            compute_hook.do_power_limit_prologue(self._mock_event)
 
         # Assert hook accepts the event
         self._mock_event.accept.assert_called_once()
@@ -229,10 +241,9 @@ class TestPowerLimitPrologue(unittest.TestCase):
                                  mock_write_control, mock_read_signal):
         JOB_POWER_LIMIT = 300
         MAX_NODE_POWER_LIMIT = 200
-        self._mock_server_job.Resource_List = {
-            compute_hook._JOB_POWER_LIMIT_RESOURCE: JOB_POWER_LIMIT,
-        }
-
+        write_resource_file(self.JOB_ID, {
+            compute_hook._JOB_POWER_LIMIT_RESOURCE: JOB_POWER_LIMIT
+        })
         A1 = 1
         A2 = A1  # Same model for each node --> Same power limit for each node
         mock_file_contents = dict(
@@ -266,8 +277,20 @@ class TestPowerLimitPrologue(unittest.TestCase):
         power_limit_setting = compute_hook._power_limit_control.copy()
 
         self._mock_pbs.get_local_nodename.return_value = node1.name
-        with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_file_contents))):
-            compute_hook.do_power_limit_prologue()
+
+        def mock_open_side_effect(filename, *args, **kwargs):
+            if filename == RESOURCE_TMP_DIR + f"/{self.JOB_ID}.resources":
+                return mock.mock_open(read_data=f"{compute_hook._JOB_POWER_LIMIT_RESOURCE}={JOB_POWER_LIMIT}").return_value
+            elif filename == self.HOOK_CONFIG_PATH:
+                return mock.mock_open(read_data=json.dumps(mock_file_contents)).return_value
+            elif filename == SAVED_CONTROLS_FILE:
+                return mock.mock_open().return_value
+            else:
+                raise FileNotFoundError(f"File not found: {filename}")
+
+        with mock.patch("builtins.open", side_effect=mock_open_side_effect):
+            compute_hook.do_power_limit_prologue(self._mock_event)
+
         node_1_power_write = next(
             call[0][3] for call in mock_write_control.call_args_list
             if call[0][0] == power_limit_setting["name"] and
@@ -276,8 +299,8 @@ class TestPowerLimitPrologue(unittest.TestCase):
         mock_write_control.reset_mock()
 
         self._mock_pbs.get_local_nodename.return_value = node2.name
-        with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_file_contents))):
-            compute_hook.do_power_limit_prologue()
+        with mock.patch("builtins.open", side_effect=mock_open_side_effect):
+            compute_hook.do_power_limit_prologue(self._mock_event)
         node_2_power_write = next(
             call[0][3] for call in mock_write_control.call_args_list
             if call[0][0] == power_limit_setting["name"] and
@@ -299,14 +322,17 @@ class TestPowerLimitPrologue(unittest.TestCase):
         # Test that both nodes have the same expected slowdown
         self.assertAlmostEqual(node_1_slowdown, node_2_slowdown)
 
+        # Test the job was accepted; prologue called twice
+        self._mock_event.accept.assert_has_calls([mock.call(), mock.call()])
+        self._mock_event.reject.assert_not_called()
+
     def test_non_uniform_power_limit(self, mock_secure_make_dirs,
                                      mock_write_control, mock_read_signal):
         JOB_POWER_LIMIT = 300
         MAX_NODE_POWER_LIMIT = 200
-        self._mock_server_job.Resource_List = {
-            compute_hook._JOB_POWER_LIMIT_RESOURCE: JOB_POWER_LIMIT,
-        }
-
+        write_resource_file(self.JOB_ID, {
+            compute_hook._JOB_POWER_LIMIT_RESOURCE: JOB_POWER_LIMIT
+        })
         A1 = 1
         A2 = 1.1  # A1 != A2 --> Expect non-uniform power caps
         mock_file_contents = dict(
@@ -340,10 +366,20 @@ class TestPowerLimitPrologue(unittest.TestCase):
         self._mock_event.vnode_list.values.return_value = [node1, node2]
         power_limit_setting = compute_hook._power_limit_control.copy()
 
+        def mock_open_side_effect(filename, *args, **kwargs):
+            if filename == RESOURCE_TMP_DIR + f"/{self.JOB_ID}.resources":
+                return mock.mock_open(read_data=f"{compute_hook._JOB_POWER_LIMIT_RESOURCE}={JOB_POWER_LIMIT}").return_value
+            elif filename == self.HOOK_CONFIG_PATH:
+                return mock.mock_open(read_data=json.dumps(mock_file_contents)).return_value
+            elif filename == SAVED_CONTROLS_FILE:
+                return mock.mock_open().return_value
+            else:
+                raise FileNotFoundError(f"File not found: {filename}")
+
         # Simulate each of node 1 and node 2 getting their prologues called
         self._mock_pbs.get_local_nodename.return_value = node1.name
-        with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_file_contents))):
-            compute_hook.do_power_limit_prologue()
+        with mock.patch("builtins.open", side_effect=mock_open_side_effect):
+            compute_hook.do_power_limit_prologue(self._mock_event)
         node_1_power_write = next(
             call[0][3] for call in mock_write_control.call_args_list
             if call[0][0] == power_limit_setting["name"] and
@@ -352,8 +388,8 @@ class TestPowerLimitPrologue(unittest.TestCase):
         mock_write_control.reset_mock()
 
         self._mock_pbs.get_local_nodename.return_value = node2.name
-        with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_file_contents))):
-            compute_hook.do_power_limit_prologue()
+        with mock.patch("builtins.open", side_effect=mock_open_side_effect):
+            compute_hook.do_power_limit_prologue(self._mock_event)
         node_2_power_write = next(
             call[0][3] for call in mock_write_control.call_args_list
             if call[0][0] == power_limit_setting["name"] and
@@ -366,6 +402,84 @@ class TestPowerLimitPrologue(unittest.TestCase):
         self.assertLessEqual(node_1_power_write, MAX_NODE_POWER_LIMIT)
         self.assertLessEqual(node_2_power_write, MAX_NODE_POWER_LIMIT)
         self.assertGreaterEqual(node_1_power_write, 0)
+
+        # Test the job was accepted; prologue called twice
+        self._mock_event.accept.assert_has_calls([mock.call(), mock.call()])
+        self._mock_event.reject.assert_not_called()
+
+
+@mock.patch("geopmdpy.pio.write_control")
+class TestPowerLimitEpilogue(unittest.TestCase):
+    def setUp(self):
+        self._mock_pbs = compute_hook.pbs
+        self._mock_event = mock.Mock()
+        self._mock_pbs.event.return_value = self._mock_event
+
+    def tearDown(self):
+        try:
+            os.unlink(SAVED_CONTROLS_FILE)
+        except:
+            pass
+
+    def test_no_settings_to_restore(self, mock_write_control):
+        self.assertFalse(os.path.exists(SAVED_CONTROLS_FILE))
+        compute_hook.do_power_limit_epilogue()
+        self._mock_event.accept.assert_called_once()
+        mock_write_control.assert_not_called()
+
+    def test_settings_restored(self, mock_write_control):
+        write_settings_to_file(SAVED_CONTROLS_FILE, CURRENT_SETTINGS)
+        compute_hook.do_power_limit_epilogue()
+        self._mock_event.accept.assert_called_once()
+        expected_calls = [
+            mock.call(d["name"], d["domain_type"], d["domain_idx"],
+                      d["setting"])
+            for d in CURRENT_SETTINGS]
+        mock_write_control.assert_has_calls(expected_calls, any_order=True)
+        self.assertFalse(os.path.exists(SAVED_CONTROLS_FILE))
+
+    def test_invalid_saved_controls_file(self, mock_write_control):
+        write_settings_to_file(SAVED_CONTROLS_FILE, [{"name": "BAD", "foo": "bar"}])
+        self._mock_event.reject.side_effect = RuntimeError
+        with self.assertRaises(RuntimeError):
+            compute_hook.do_power_limit_epilogue()
+        self._mock_event.reject.assert_called_once()
+        self._mock_event.accept.assert_not_called()
+        mock_write_control.assert_not_called()
+
+
+# Main hook tests (single cached event expectation)
+@mock.patch("geopm_power_limit_compute.do_power_limit_prologue")
+@mock.patch("geopm_power_limit_compute.do_power_limit_epilogue")
+class TestPowerLimitMain(unittest.TestCase):
+    def setUp(self):
+        self._mock_pbs = compute_hook.pbs
+        self._mock_event = mock.Mock()
+        self._mock_pbs.event.return_value = self._mock_event
+        self._mock_pbs.EXECJOB_PROLOGUE = 1
+        self._mock_pbs.EXECJOB_EPILOGUE = 2
+
+    def test_prologue(self, mock_epilogue, mock_prologue):
+        self._mock_event.type = self._mock_pbs.EXECJOB_PROLOGUE
+        compute_hook.hook_main()
+        mock_epilogue.assert_not_called()
+        mock_prologue.assert_called_once()
+        self._mock_event.reject.assert_not_called()
+
+    def test_epilogue(self, mock_epilogue, mock_prologue):
+        self._mock_event.type = self._mock_pbs.EXECJOB_EPILOGUE
+        compute_hook.hook_main()
+        mock_epilogue.assert_called_once()
+        mock_prologue.assert_not_called()
+        self._mock_event.reject.assert_not_called()
+
+    def test_invalid_event(self, mock_epilogue, mock_prologue):
+        self._mock_event.type = 999
+        compute_hook.hook_main()
+        mock_epilogue.assert_not_called()
+        mock_prologue.assert_not_called()
+        self._mock_event.reject.assert_called_once()
+        self._mock_event.accept.assert_not_called()
         self.assertGreaterEqual(node_2_power_write, 0)
         self.assertNotEqual(node_1_power_write, node_2_power_write)
 
@@ -393,7 +507,7 @@ class TestPowerLimitEpilogue(unittest.TestCase):
         # Ensure there is no file prior to running the test
         self.assertFalse(os.path.exists(SAVED_CONTROLS_FILE))
 
-        compute_hook.do_power_limit_epilogue()
+        compute_hook.do_power_limit_epilogue(self._mock_event)
 
         # Assert hook accepts event
         self._mock_event.accept.assert_called_once()
@@ -404,7 +518,7 @@ class TestPowerLimitEpilogue(unittest.TestCase):
         # Create some settings to restore
         write_settings_to_file(SAVED_CONTROLS_FILE, CURRENT_SETTINGS)
 
-        compute_hook.do_power_limit_epilogue()
+        compute_hook.do_power_limit_epilogue(self._mock_event)
 
         # Assert hook accepts the event
         self._mock_event.accept.assert_called_once()
@@ -426,7 +540,7 @@ class TestPowerLimitEpilogue(unittest.TestCase):
         self._mock_event.reject.side_effect = RuntimeError
 
         with self.assertRaises(RuntimeError):
-            compute_hook.do_power_limit_epilogue()
+            compute_hook.do_power_limit_epilogue(self._mock_event)
 
         # Assert hook rejects the event
         self._mock_event.reject.assert_called_once()

--- a/integration/service/open_pbs/TestPowerLimitHook.py
+++ b/integration/service/open_pbs/TestPowerLimitHook.py
@@ -13,7 +13,8 @@ import copy
 
 mock.patch.dict("sys.modules", pbs=mock.MagicMock()).start()
 mock.patch("cffi.FFI.dlopen").start()
-import geopm_power_limit as hook
+import geopm_power_limit_compute as compute_hook
+import geopm_power_limit_server as server_hook
 
 
 SAVED_CONTROLS_FILE = "saved_controls.json"
@@ -66,7 +67,7 @@ def write_settings_to_file(file_name, settings):
 
 
 def setUpModule():
-    hook._SAVED_CONTROLS_FILE = SAVED_CONTROLS_FILE
+    compute_hook._SAVED_CONTROLS_FILE = SAVED_CONTROLS_FILE
 
 class MockAttr():
     def __init__(self, value):
@@ -88,7 +89,7 @@ class TestPowerLimitPrologue(unittest.TestCase):
     JOB_ID = 1
 
     def setUp(self):
-        self._mock_pbs = hook.pbs
+        self._mock_pbs = server_hook.pbs
         self._mock_event = mock.Mock()
         self._mock_server = mock.Mock()
         self._mock_server_job = mock.Mock()
@@ -110,12 +111,12 @@ class TestPowerLimitPrologue(unittest.TestCase):
         REQUESTED_POWER_LIMIT = 240000000
 
         self._mock_server_job.Resource_List = {
-            hook._POWER_LIMIT_RESOURCE: REQUESTED_POWER_LIMIT,
+            compute_hook._POWER_LIMIT_RESOURCE: REQUESTED_POWER_LIMIT,
         }
 
         # Prepare expectations
-        new_settings = copy.deepcopy(hook._controls)
-        power_limit_setting = hook._power_limit_control.copy()
+        new_settings = copy.deepcopy(compute_hook._controls)
+        power_limit_setting = compute_hook._power_limit_control.copy()
         power_limit_setting["setting"] = REQUESTED_POWER_LIMIT
         expected_calls = [
             mock.call(d["name"], d["domain_type"], d["domain_idx"],
@@ -126,12 +127,12 @@ class TestPowerLimitPrologue(unittest.TestCase):
                                         power_limit_setting["domain_idx"],
                                         power_limit_setting["setting"]))
 
-        hook.do_power_limit_prologue()
+        compute_hook.do_power_limit_prologue()
 
         # Assert prologue gets the right server job
         self._mock_server.job.assert_called_with(self.JOB_ID)
         # Assert saved controls path is created securely
-        mock_secure_make_dirs.assert_called_with(hook._SAVED_CONTROLS_PATH)
+        mock_secure_make_dirs.assert_called_with(compute_hook._SAVED_CONTROLS_PATH)
         # Assert settings are saved to file
         saved_settings = read_settings_from_file(SAVED_CONTROLS_FILE)
         self.assertEqual(saved_settings, CURRENT_SETTINGS)
@@ -147,13 +148,13 @@ class TestPowerLimitPrologue(unittest.TestCase):
         REQUESTED_POWER_LIMIT = "not a number"
 
         self._mock_server_job.Resource_List = {
-                hook._POWER_LIMIT_RESOURCE: REQUESTED_POWER_LIMIT}
+                compute_hook._POWER_LIMIT_RESOURCE: REQUESTED_POWER_LIMIT}
         self._mock_pbs.EXECJOB_PROLOGUE = 'execjob_prologue_event_type'
         self._mock_event.type = self._mock_pbs.EXECJOB_PROLOGUE
         self._mock_event.reject.side_effect = RuntimeError
 
         with self.assertRaises(RuntimeError):
-            hook.do_power_limit_prologue()
+            compute_hook.do_power_limit_prologue()
 
         # Assert job gets removed from queue upon failure
         self._mock_event.job.delete.assert_called_once()
@@ -168,7 +169,7 @@ class TestPowerLimitPrologue(unittest.TestCase):
                                        mock_write_control, mock_read_signal):
         self._mock_server_job.Resource_List = {}
 
-        hook.do_power_limit_prologue()
+        compute_hook.do_power_limit_prologue()
 
         # Assert hook accepts the event
         self._mock_event.accept.assert_called_once()
@@ -189,7 +190,7 @@ class TestPowerLimitPrologue(unittest.TestCase):
         # execution. Using an exception here to simulate the same side effect.
         self._mock_event.accept.side_effect = RuntimeError
         with self.assertRaises(RuntimeError):
-            hook.do_power_limit_prologue()
+            compute_hook.do_power_limit_prologue()
 
         # Assert hook accepts the event
         self._mock_event.accept.assert_called_once()
@@ -210,7 +211,7 @@ class TestPowerLimitPrologue(unittest.TestCase):
         JOB_POWER_LIMIT = 300
         MAX_NODE_POWER_LIMIT = 200
         self._mock_server_job.Resource_List = {
-            hook._JOB_POWER_LIMIT_RESOURCE: JOB_POWER_LIMIT,
+            compute_hook._JOB_POWER_LIMIT_RESOURCE: JOB_POWER_LIMIT,
         }
 
         A1 = 1
@@ -243,11 +244,11 @@ class TestPowerLimitPrologue(unittest.TestCase):
         node2 = mock.Mock()
         node2.name = 'test-host-2'
         self._mock_event.vnode_list.values.return_value = [node1, node2]
-        power_limit_setting = hook._power_limit_control.copy()
+        power_limit_setting = compute_hook._power_limit_control.copy()
 
         self._mock_pbs.get_local_nodename.return_value = node1.name
         with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_file_contents))):
-            hook.do_power_limit_prologue()
+            compute_hook.do_power_limit_prologue()
         node_1_power_write = next(
             call[0][3] for call in mock_write_control.call_args_list
             if call[0][0] == power_limit_setting["name"] and
@@ -257,7 +258,7 @@ class TestPowerLimitPrologue(unittest.TestCase):
 
         self._mock_pbs.get_local_nodename.return_value = node2.name
         with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_file_contents))):
-            hook.do_power_limit_prologue()
+            compute_hook.do_power_limit_prologue()
         node_2_power_write = next(
             call[0][3] for call in mock_write_control.call_args_list
             if call[0][0] == power_limit_setting["name"] and
@@ -284,7 +285,7 @@ class TestPowerLimitPrologue(unittest.TestCase):
         JOB_POWER_LIMIT = 300
         MAX_NODE_POWER_LIMIT = 200
         self._mock_server_job.Resource_List = {
-            hook._JOB_POWER_LIMIT_RESOURCE: JOB_POWER_LIMIT,
+            compute_hook._JOB_POWER_LIMIT_RESOURCE: JOB_POWER_LIMIT,
         }
 
         A1 = 1
@@ -318,12 +319,12 @@ class TestPowerLimitPrologue(unittest.TestCase):
         node2 = mock.Mock()
         node2.name = 'test-host-2'
         self._mock_event.vnode_list.values.return_value = [node1, node2]
-        power_limit_setting = hook._power_limit_control.copy()
+        power_limit_setting = compute_hook._power_limit_control.copy()
 
         # Simulate each of node 1 and node 2 getting their prologues called
         self._mock_pbs.get_local_nodename.return_value = node1.name
         with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_file_contents))):
-            hook.do_power_limit_prologue()
+            compute_hook.do_power_limit_prologue()
         node_1_power_write = next(
             call[0][3] for call in mock_write_control.call_args_list
             if call[0][0] == power_limit_setting["name"] and
@@ -333,7 +334,7 @@ class TestPowerLimitPrologue(unittest.TestCase):
 
         self._mock_pbs.get_local_nodename.return_value = node2.name
         with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_file_contents))):
-            hook.do_power_limit_prologue()
+            compute_hook.do_power_limit_prologue()
         node_2_power_write = next(
             call[0][3] for call in mock_write_control.call_args_list
             if call[0][0] == power_limit_setting["name"] and
@@ -359,7 +360,7 @@ class TestPowerLimitPrologue(unittest.TestCase):
 @mock.patch("geopmdpy.pio.write_control")
 class TestPowerLimitEpilogue(unittest.TestCase):
     def setUp(self):
-        self._mock_pbs = hook.pbs
+        self._mock_pbs = server_hook.pbs
         self._mock_event = mock.Mock()
         self._mock_pbs.event.return_value = self._mock_event
 
@@ -373,7 +374,7 @@ class TestPowerLimitEpilogue(unittest.TestCase):
         # Ensure there is no file prior to running the test
         self.assertFalse(os.path.exists(SAVED_CONTROLS_FILE))
 
-        hook.do_power_limit_epilogue()
+        compute_hook.do_power_limit_epilogue()
 
         # Assert hook accepts event
         self._mock_event.accept.assert_called_once()
@@ -384,7 +385,7 @@ class TestPowerLimitEpilogue(unittest.TestCase):
         # Create some settings to restore
         write_settings_to_file(SAVED_CONTROLS_FILE, CURRENT_SETTINGS)
 
-        hook.do_power_limit_epilogue()
+        compute_hook.do_power_limit_epilogue()
 
         # Assert hook accepts the event
         self._mock_event.accept.assert_called_once()
@@ -406,7 +407,7 @@ class TestPowerLimitEpilogue(unittest.TestCase):
         self._mock_event.reject.side_effect = RuntimeError
 
         with self.assertRaises(RuntimeError):
-            hook.do_power_limit_epilogue()
+            compute_hook.do_power_limit_epilogue()
 
         # Assert hook rejects the event
         self._mock_event.reject.assert_called_once()
@@ -415,11 +416,11 @@ class TestPowerLimitEpilogue(unittest.TestCase):
         mock_write_control.assert_not_called()
 
 
-@mock.patch("geopm_power_limit.do_power_limit_prologue")
-@mock.patch("geopm_power_limit.do_power_limit_epilogue")
+@mock.patch("geopm_power_limit_compute.do_power_limit_prologue")
+@mock.patch("geopm_power_limit_compute.do_power_limit_epilogue")
 class TestPowerLimitMain(unittest.TestCase):
     def setUp(self):
-        self._mock_pbs = hook.pbs
+        self._mock_pbs = server_hook.pbs
         self._mock_event = mock.Mock()
         self._mock_pbs.event.return_value = self._mock_event
         self._mock_pbs.EXECJOB_PROLOGUE = 1
@@ -429,7 +430,7 @@ class TestPowerLimitMain(unittest.TestCase):
         # Simulate the prologue event
         self._mock_event.type = self._mock_pbs.EXECJOB_PROLOGUE
 
-        hook.hook_main()
+        compute_hook.hook_main()
 
         # Assert only the prologue is executed
         mock_epilogue.assert_not_called()
@@ -441,7 +442,7 @@ class TestPowerLimitMain(unittest.TestCase):
         # Simulate the epilogue event
         self._mock_event.type = self._mock_pbs.EXECJOB_EPILOGUE
 
-        hook.hook_main()
+        compute_hook.hook_main()
 
         # Assert only the epilogue is executed
         mock_epilogue.assert_called_once()
@@ -454,7 +455,7 @@ class TestPowerLimitMain(unittest.TestCase):
                            self._mock_pbs.EXECJOB_EPILOGUE
         self._mock_event.type = SOME_OTHER_EVENT
 
-        hook.hook_main()
+        compute_hook.hook_main()
 
         # Neither prologue or epilogue should be called and event should be
         # rejected
@@ -468,7 +469,7 @@ class TestPowerLimitQueuejob(unittest.TestCase):
     JOB_ID = 1
 
     def setUp(self):
-        self._mock_pbs = hook.pbs
+        self._mock_pbs = server_hook.pbs
         self._mock_server = mock.Mock()
         self._mock_event = mock.Mock()
         self._mock_event_job = mock.Mock()
@@ -480,10 +481,10 @@ class TestPowerLimitQueuejob(unittest.TestCase):
         self._mock_pbs.hook_config_filename = None
 
         self._mock_event_job.Resource_List = {
-            hook._JOB_POWER_LIMIT_RESOURCE: None,
-            hook._POWER_LIMIT_RESOURCE: None,
-            hook._DEFAULT_SLOWDOWN_RESOURCE: None,
-            hook._JOB_TYPE_RESOURCE: None,
+            server_hook._JOB_POWER_LIMIT_RESOURCE: None,
+            server_hook._POWER_LIMIT_RESOURCE: None,
+            server_hook._DEFAULT_SLOWDOWN_RESOURCE: None,
+            server_hook._JOB_TYPE_RESOURCE: None,
         }
 
         self._MIN_NODE_POWER_LIMIT = 500
@@ -495,24 +496,24 @@ class TestPowerLimitQueuejob(unittest.TestCase):
         REQUESTED_NODE_POWER_LIMIT = 1000
         NODE_COUNT = 2
 
-        self._mock_event_job.Resource_List[hook._POWER_LIMIT_RESOURCE] = REQUESTED_NODE_POWER_LIMIT
+        self._mock_event_job.Resource_List[server_hook._POWER_LIMIT_RESOURCE] = REQUESTED_NODE_POWER_LIMIT
         self._mock_event_job.Resource_List['select'] = MockAttr(NODE_COUNT)
 
         self._mock_server.resources_available = {
             # Available job power can be anything except None for this case (if None,
             # then there's no need to auto-set job power)
-            hook._JOB_POWER_LIMIT_RESOURCE: REQUESTED_NODE_POWER_LIMIT * NODE_COUNT,
-            hook._MAX_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT,
-            hook._MIN_POWER_LIMIT_RESOURCE: self._MIN_NODE_POWER_LIMIT,
+            server_hook._JOB_POWER_LIMIT_RESOURCE: REQUESTED_NODE_POWER_LIMIT * NODE_COUNT,
+            server_hook._MAX_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT,
+            server_hook._MIN_POWER_LIMIT_RESOURCE: self._MIN_NODE_POWER_LIMIT,
         }
 
-        hook.do_power_limit_queuejob()
+        server_hook.do_power_limit_queuejob()
 
-        self.assertEqual(self._mock_event_job.Resource_List[hook._POWER_LIMIT_RESOURCE],
+        self.assertEqual(self._mock_event_job.Resource_List[server_hook._POWER_LIMIT_RESOURCE],
                          REQUESTED_NODE_POWER_LIMIT)
 
         # The assigned job limit should be consistent with the requested node limit
-        self.assertEqual(self._mock_event_job.Resource_List[hook._JOB_POWER_LIMIT_RESOURCE],
+        self.assertEqual(self._mock_event_job.Resource_List[server_hook._JOB_POWER_LIMIT_RESOURCE],
                          NODE_COUNT * REQUESTED_NODE_POWER_LIMIT)
 
     def test_no_user_power_limit_with_high_admin_limit(self):
@@ -520,16 +521,16 @@ class TestPowerLimitQueuejob(unittest.TestCase):
 
         self._mock_event_job.Resource_List['select'] = MockAttr(NODE_COUNT)
         self._mock_server.resources_available = {
-            hook._JOB_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT * NODE_COUNT,
-            hook._MAX_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT,
-            hook._MIN_POWER_LIMIT_RESOURCE: self._MIN_NODE_POWER_LIMIT,
+            server_hook._JOB_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT * NODE_COUNT,
+            server_hook._MAX_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT,
+            server_hook._MIN_POWER_LIMIT_RESOURCE: self._MIN_NODE_POWER_LIMIT,
         }
 
-        hook.do_power_limit_queuejob()
+        server_hook.do_power_limit_queuejob()
 
         # Node power limit is only auto-set in the prologue. The queue hook only sets job power.
-        self.assertIsNone(self._mock_event_job.Resource_List[hook._POWER_LIMIT_RESOURCE])
-        self.assertEqual(self._mock_event_job.Resource_List[hook._JOB_POWER_LIMIT_RESOURCE],
+        self.assertIsNone(self._mock_event_job.Resource_List[server_hook._POWER_LIMIT_RESOURCE])
+        self.assertEqual(self._mock_event_job.Resource_List[server_hook._JOB_POWER_LIMIT_RESOURCE],
                          self._MAX_NODE_POWER_LIMIT * NODE_COUNT)
 
     def test_no_user_power_limit_with_low_admin_limit(self):
@@ -537,17 +538,17 @@ class TestPowerLimitQueuejob(unittest.TestCase):
 
         self._mock_event_job.Resource_List['select'] = MockAttr(NODE_COUNT)
         self._mock_server.resources_available = {
-            hook._JOB_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT * NODE_COUNT / 2,
-            hook._MAX_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT,
-            hook._MIN_POWER_LIMIT_RESOURCE: self._MIN_NODE_POWER_LIMIT,
+            server_hook._JOB_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT * NODE_COUNT / 2,
+            server_hook._MAX_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT,
+            server_hook._MIN_POWER_LIMIT_RESOURCE: self._MIN_NODE_POWER_LIMIT,
         }
 
-        hook.do_power_limit_queuejob()
+        server_hook.do_power_limit_queuejob()
 
         # Node power limit is only auto-set in the prologue. The queue hook only sets job power.
-        self.assertIsNone(self._mock_event_job.Resource_List[hook._POWER_LIMIT_RESOURCE])
+        self.assertIsNone(self._mock_event_job.Resource_List[server_hook._POWER_LIMIT_RESOURCE])
         # Don't require more power than the whole PBS server has available
-        self.assertEqual(self._mock_event_job.Resource_List[hook._JOB_POWER_LIMIT_RESOURCE],
+        self.assertEqual(self._mock_event_job.Resource_List[server_hook._JOB_POWER_LIMIT_RESOURCE],
                          self._MAX_NODE_POWER_LIMIT * NODE_COUNT / 2)
 
     def test_no_user_power_limit_without_admin_limit(self):
@@ -555,27 +556,27 @@ class TestPowerLimitQueuejob(unittest.TestCase):
 
         self._mock_event_job.Resource_List['select'] = MockAttr(NODE_COUNT)
         self._mock_server.resources_available = {
-            hook._JOB_POWER_LIMIT_RESOURCE: None,
-            hook._MAX_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT,
-            hook._MIN_POWER_LIMIT_RESOURCE: self._MIN_NODE_POWER_LIMIT,
+            server_hook._JOB_POWER_LIMIT_RESOURCE: None,
+            server_hook._MAX_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT,
+            server_hook._MIN_POWER_LIMIT_RESOURCE: self._MIN_NODE_POWER_LIMIT,
         }
 
-        hook.do_power_limit_queuejob()
+        server_hook.do_power_limit_queuejob()
 
         # Node limit should be untouched. Job limit should be set.
-        self.assertEqual(self._mock_event_job.Resource_List[hook._POWER_LIMIT_RESOURCE], None)
-        self.assertIsNone(self._mock_event_job.Resource_List[hook._JOB_POWER_LIMIT_RESOURCE])
+        self.assertEqual(self._mock_event_job.Resource_List[server_hook._POWER_LIMIT_RESOURCE], None)
+        self.assertIsNone(self._mock_event_job.Resource_List[server_hook._JOB_POWER_LIMIT_RESOURCE])
 
     def test_user_slowdown(self):
         NODE_COUNT = 1
 
         self._mock_event_job.Resource_List['select'] = MockAttr(NODE_COUNT)
-        self._mock_event_job.Resource_List[hook._JOB_TYPE_RESOURCE] = 'test-type'
-        self._mock_event_job.Resource_List[hook._DEFAULT_SLOWDOWN_RESOURCE] = 0.75
+        self._mock_event_job.Resource_List[server_hook._JOB_TYPE_RESOURCE] = 'test-type'
+        self._mock_event_job.Resource_List[server_hook._DEFAULT_SLOWDOWN_RESOURCE] = 0.75
         self._mock_server.resources_available = {
-            hook._JOB_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT * NODE_COUNT,
-            hook._MAX_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT,
-            hook._MIN_POWER_LIMIT_RESOURCE: self._MIN_NODE_POWER_LIMIT,
+            server_hook._JOB_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT * NODE_COUNT,
+            server_hook._MAX_POWER_LIMIT_RESOURCE: self._MAX_NODE_POWER_LIMIT,
+            server_hook._MIN_POWER_LIMIT_RESOURCE: self._MIN_NODE_POWER_LIMIT,
         }
         self._mock_pbs.hook_config_filename = 'fake/file/path'
         mock_file_contents = dict(max_power=self._MAX_NODE_POWER_LIMIT, profiles={'test-type': dict(model={
@@ -589,12 +590,12 @@ class TestPowerLimitQueuejob(unittest.TestCase):
         })})
 
         with mock.patch("builtins.open", mock.mock_open(read_data=json.dumps(mock_file_contents))):
-            hook.do_power_limit_queuejob()
+            server_hook.do_power_limit_queuejob()
 
         # Node power limit is only auto-set in the prologue. The queue hook only sets job power.
-        self.assertIsNone(self._mock_event_job.Resource_List[hook._POWER_LIMIT_RESOURCE])
+        self.assertIsNone(self._mock_event_job.Resource_List[server_hook._POWER_LIMIT_RESOURCE])
 
-        self.assertEqual(self._mock_event_job.Resource_List[hook._JOB_POWER_LIMIT_RESOURCE],
+        self.assertEqual(self._mock_event_job.Resource_List[server_hook._JOB_POWER_LIMIT_RESOURCE],
                          self._MAX_NODE_POWER_LIMIT * .5)
 
 

--- a/integration/service/open_pbs/geopm_install_pbs_power_limit.sh
+++ b/integration/service/open_pbs/geopm_install_pbs_power_limit.sh
@@ -10,6 +10,7 @@ JOB_RESOURCE="geopm-job-power-limit"
 JOB_TYPE_RESOURCE="geopm-job-type"
 DEFAULT_SLOWDOWN_RESOURCE="geopm-default-slowdown"
 NODE_CAP_HOOK="geopm_power_limit"
+QUEUEJOB_HOOK="geopm_power_limit_queuejob"
 REMOVE_OPT="--remove"
 SAVED_CONTROLS_BASE_DIR="/run/geopm/pbs-hooks"
 
@@ -72,9 +73,20 @@ install() {
     else
         echo "$NODE_CAP_HOOK hook already exists"
     fi
-    echo "Importing and configuring hook..."
-    qmgr -c "import hook $NODE_CAP_HOOK application/x-python default ${NODE_CAP_HOOK}.py" || exit 1
-    qmgr -c "set hook $NODE_CAP_HOOK event='queuejob,runjob,execjob_prologue,execjob_epilogue'" || exit 1
+    echo "Importing and configuring prologue/epilogue hook..."
+    qmgr -c "import hook $NODE_CAP_HOOK application/x-python default geopm_power_limit_compute.py" || exit 1
+    qmgr -c "set hook $NODE_CAP_HOOK event='execjob_prologue,execjob_epilogue'" || exit 1
+
+    out=`qmgr -c "list hook" | grep "$QUEUEJOB_HOOK"`
+    if [ -z "$out" ]; then
+        echo "Creating $QUEUEJOB_HOOK hook..."
+        qmgr -c "create hook $QUEUEJOB_HOOK" || exit 1
+    else
+        echo "$QUEUEJOB_HOOK hook already exists"
+    fi
+    echo "Importing and configuring queuejob hook..."
+    qmgr -c "import hook $QUEUEJOB_HOOK application/x-python default geopm_power_limit_server.py" || exit 1
+    qmgr -c "set hook $QUEUEJOB_HOOK event='queuejob'" || exit 1
 
     echo "Done."
 }
@@ -103,7 +115,15 @@ remove() {
         echo "$NODE_CAP_HOOK hook not found"
     else
         echo "Removing $NODE_CAP_HOOK hook..."
-        qmgr -c "delete hook $EXECHOST_HOOK" || exit 1
+        qmgr -c "delete hook $NODE_CAP_HOOK" || exit 1
+    fi
+
+    out=`qmgr -c "list hook" | grep "$QUEUEJOB_HOOK"`
+    if [ -z "$out" ]; then
+        echo "$QUEUEJOB_HOOK hook not found"
+    else
+        echo "Removing $QUEUEJOB_HOOK hook..."
+        qmgr -c "delete hook $QUEUEJOB_HOOK" || exit 1
     fi
 
     rm -rf "$SAVED_CONTROLS_BASE_DIR"
@@ -116,6 +136,8 @@ if [ $# -eq 0 ]; then
     echo "$SCHED_CONFIG_MODIFIED_MESSAGE"
     echo ""
     echo "GEOPM PBS plugins have been installed but are not yet configured."
+    echo "The prologue/epilogue hook ($NODE_CAP_HOOK) needs to be installed on all compute nodes."
+    echo "The queuejob hook ($QUEUEJOB_HOOK) needs to be installed on the PBS server."
     echo "To set a power limit across jobs, set resources_available for $JOB_RESOURCE"
     echo "To set a minimum node power limit, use $NODE_MIN_RESOURCE"
     echo "To set a maximum node power limit, use $NODE_MAX_RESOURCE"

--- a/integration/service/open_pbs/geopm_install_pbs_power_limit_compute.sh
+++ b/integration/service/open_pbs/geopm_install_pbs_power_limit_compute.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#  Copyright (c) 2015 - 2025 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+
+# Resources needed for the compute nodes
+NODE_RESOURCE="geopm-node-power-limit"
+JOB_RESOURCE="geopm-job-power-limit"
+NODE_CAP_HOOK="geopm_power_limit"
+REMOVE_OPT="--remove"
+SAVED_CONTROLS_BASE_DIR="/run/geopm/pbs-hooks"
+
+# Set the location of PBS_HOME by sourcing the PBS config.
+source '/etc/pbs.conf'
+
+print_usage() {
+    echo "
+    Usage: $0 [${REMOVE_OPT}]
+
+    Invoking this script with no arguments installs the GEOPM power limit
+    compute hook for prologue and epilogue events.
+
+    Use the --remove option to uninstall the hook and remove the saved controls directory.
+    "
+}
+
+install() {
+    # Create directories for saved controls
+    mkdir -p "${SAVED_CONTROLS_BASE_DIR}/SAVE_FILES"
+    chmod 755 "${SAVED_CONTROLS_BASE_DIR}"
+    chmod 755 "${SAVED_CONTROLS_BASE_DIR}/SAVE_FILES"
+
+    # Set up the prologue/epilogue hook
+    out=`qmgr -c "list hook" | grep "$NODE_CAP_HOOK"`
+    if [ -z "$out" ]; then
+        echo "Creating $NODE_CAP_HOOK hook..."
+        qmgr -c "create hook $NODE_CAP_HOOK" || exit 1
+    else
+        echo "$NODE_CAP_HOOK hook already exists"
+    fi
+    echo "Importing and configuring prologue/epilogue hook..."
+    qmgr -c "import hook $NODE_CAP_HOOK application/x-python default geopm_power_limit_compute.py" || exit 1
+    qmgr -c "set hook $NODE_CAP_HOOK event='execjob_prologue,execjob_epilogue'" || exit 1
+
+    echo "Done."
+}
+
+remove() {
+    # Remove the prologue/epilogue hook
+    out=`qmgr -c "list hook" | grep "$NODE_CAP_HOOK"`
+    if [ -z "$out" ]; then
+        echo "$NODE_CAP_HOOK hook not found"
+    else
+        echo "Removing $NODE_CAP_HOOK hook..."
+        qmgr -c "delete hook $NODE_CAP_HOOK" || exit 1
+    fi
+
+    # Remove saved controls directory
+    rm -rf "$SAVED_CONTROLS_BASE_DIR"
+
+    echo "Done."
+}
+
+if [ $# -eq 0 ]; then
+    install
+    echo ""
+    echo "GEOPM PBS compute node hook has been installed."
+    echo "Note: This hook uses resources that must be defined on the PBS server."
+    echo "Make sure to run the server installation script on the PBS server."
+elif [ $# -eq 1 ]; then
+    if [ "$1" == "$REMOVE_OPT" ]; then
+        remove
+    else
+        echo "Unrecognized option: $1"
+        print_usage
+    fi
+else
+    echo "Invalid number of arguments"
+    print_usage
+fi

--- a/integration/service/open_pbs/geopm_install_pbs_power_limit_compute.sh
+++ b/integration/service/open_pbs/geopm_install_pbs_power_limit_compute.sh
@@ -3,10 +3,7 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 
-# Resources needed for the compute nodes
-NODE_RESOURCE="geopm-node-power-limit"
-JOB_RESOURCE="geopm-job-power-limit"
-NODE_CAP_HOOK="geopm_power_limit"
+COMPUTE_HOOK="geopm_power_limit_compute"
 REMOVE_OPT="--remove"
 SAVED_CONTROLS_BASE_DIR="/run/geopm/pbs-hooks"
 
@@ -25,34 +22,29 @@ print_usage() {
 }
 
 install() {
-    # Create directories for saved controls
-    mkdir -p "${SAVED_CONTROLS_BASE_DIR}/SAVE_FILES"
-    chmod 755 "${SAVED_CONTROLS_BASE_DIR}"
-    chmod 755 "${SAVED_CONTROLS_BASE_DIR}/SAVE_FILES"
-
     # Set up the prologue/epilogue hook
-    out=`qmgr -c "list hook" | grep "$NODE_CAP_HOOK"`
+    out=`qmgr -c "list hook" | grep "$COMPUTE_HOOK"`
     if [ -z "$out" ]; then
-        echo "Creating $NODE_CAP_HOOK hook..."
-        qmgr -c "create hook $NODE_CAP_HOOK" || exit 1
+        echo "Creating $COMPUTE_HOOK hook..."
+        qmgr -c "create hook $COMPUTE_HOOK" || exit 1
     else
-        echo "$NODE_CAP_HOOK hook already exists"
+        echo "$COMPUTE_HOOK hook already exists"
     fi
     echo "Importing and configuring prologue/epilogue hook..."
-    qmgr -c "import hook $NODE_CAP_HOOK application/x-python default geopm_power_limit_compute.py" || exit 1
-    qmgr -c "set hook $NODE_CAP_HOOK event='execjob_prologue,execjob_epilogue'" || exit 1
+    qmgr -c "import hook $COMPUTE_HOOK application/x-python default $COMPUTE_HOOK.py" || exit 1
+    qmgr -c "set hook $COMPUTE_HOOK event='execjob_prologue,execjob_epilogue'" || exit 1
 
     echo "Done."
 }
 
 remove() {
     # Remove the prologue/epilogue hook
-    out=`qmgr -c "list hook" | grep "$NODE_CAP_HOOK"`
+    out=`qmgr -c "list hook" | grep "$COMPUTE_HOOK"`
     if [ -z "$out" ]; then
-        echo "$NODE_CAP_HOOK hook not found"
+        echo "$COMPUTE_HOOK hook not found"
     else
-        echo "Removing $NODE_CAP_HOOK hook..."
-        qmgr -c "delete hook $NODE_CAP_HOOK" || exit 1
+        echo "Removing $COMPUTE_HOOK hook..."
+        qmgr -c "delete hook $COMPUTE_HOOK" || exit 1
     fi
 
     # Remove saved controls directory

--- a/integration/service/open_pbs/geopm_install_pbs_power_limit_server.sh
+++ b/integration/service/open_pbs/geopm_install_pbs_power_limit_server.sh
@@ -74,7 +74,7 @@ install() {
     fi
     echo "Importing and configuring server hook..."
     qmgr -c "import hook $SERVER_HOOK application/x-python default $SERVER_HOOK.py" || exit 1
-    qmgr -c "set hook $SERVER_HOOK event='queuejob'" || exit 1
+    qmgr -c "set hook $SERVER_HOOK event='queuejob,modifyjob'" || exit 1
 
     echo "Done."
 }

--- a/integration/service/open_pbs/geopm_install_pbs_power_limit_server.sh
+++ b/integration/service/open_pbs/geopm_install_pbs_power_limit_server.sh
@@ -3,14 +3,13 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 
-# Resources needed for the server
-NODE_RESOURCE="geopm-node-power-limit"
-NODE_MAX_RESOURCE="geopm-max-node-power-limit"
-NODE_MIN_RESOURCE="geopm-min-node-power-limit"
-JOB_RESOURCE="geopm-job-power-limit"
+POWER_LIMIT_RESOURCE="geopm-node-power-limit"
+MAX_POWER_LIMIT_RESOURCE="geopm-max-node-power-limit"
+MIN_POWER_LIMIT_RESOURCE="geopm-min-node-power-limit"
+JOB_POWER_LIMIT_RESOURCE="geopm-job-power-limit"
 JOB_TYPE_RESOURCE="geopm-job-type"
 DEFAULT_SLOWDOWN_RESOURCE="geopm-default-slowdown"
-QUEUEJOB_HOOK="geopm_power_limit_queuejob"
+SERVER_HOOK="geopm_power_limit_server"
 REMOVE_OPT="--remove"
 
 SCHED_CONFIG_MODIFIED_MESSAGE="\
@@ -34,7 +33,7 @@ print_usage() {
 
 install() {
     # Create all resources needed for the server side
-    for resource in $NODE_RESOURCE $NODE_MAX_RESOURCE $NODE_MIN_RESOURCE $JOB_RESOURCE $DEFAULT_SLOWDOWN_RESOURCE
+    for resource in $POWER_LIMIT_RESOURCE $MAX_POWER_LIMIT_RESOURCE $MIN_POWER_LIMIT_RESOURCE $JOB_POWER_LIMIT_RESOURCE $DEFAULT_SLOWDOWN_RESOURCE
     do
         out=`qmgr -c "list resource" | grep "$resource"`
         if [ -z "$out" ]; then
@@ -44,11 +43,11 @@ install() {
             echo "$resource resource already exists"
         fi
     done
-    echo "Marking $JOB_RESOURCE as a server/queue resource..."
-    qmgr -c "set resource $JOB_RESOURCE flag=q" || exit 1
-    echo "Marking $NODE_MAX_RESOURCE and $NODE_MIN_RESOURCE as read-only resources..."
-    qmgr -c "set resource $NODE_MAX_RESOURCE flag=r" || exit 1
-    qmgr -c "set resource $NODE_MIN_RESOURCE flag=r" || exit 1
+    echo "Marking $JOB_POWER_LIMIT_RESOURCE as a server/queue resource..."
+    qmgr -c "set resource $JOB_POWER_LIMIT_RESOURCE flag=q" || exit 1
+    echo "Marking $MAX_POWER_LIMIT_RESOURCE and $MIN_POWER_LIMIT_RESOURCE as read-only resources..."
+    qmgr -c "set resource $MAX_POWER_LIMIT_RESOURCE flag=r" || exit 1
+    qmgr -c "set resource $MIN_POWER_LIMIT_RESOURCE flag=r" || exit 1
 
     out=`qmgr -c "list resource" | grep "$JOB_TYPE_RESOURCE"`
     if [ -z "$out" ]; then
@@ -58,38 +57,38 @@ install() {
         echo "$JOB_TYPE_RESOURCE resource already exists"
     fi
 
-    if grep -q "^resources: .*$JOB_RESOURCE" "${PBS_HOME}/sched_priv/sched_config"; then
-            echo "$JOB_RESOURCE is already defined as a consumable scheduler resource"
+    if grep -q "^resources: .*$JOB_POWER_LIMIT_RESOURCE" "${PBS_HOME}/sched_priv/sched_config"; then
+            echo "$JOB_POWER_LIMIT_RESOURCE is already defined as a consumable scheduler resource"
     else
-            echo "Appending $JOB_RESOURCE as a consumable scheduler resource"
-            sed -i -e "s/^resources: \"\([^\"]\+\)\"$/resources: \"\1, ${JOB_RESOURCE}\"/g" "${PBS_HOME}/sched_priv/sched_config"
+            echo "Appending $JOB_POWER_LIMIT_RESOURCE as a consumable scheduler resource"
+            sed -i -e "s/^resources: \"\([^\"]\+\)\"$/resources: \"\1, ${JOB_POWER_LIMIT_RESOURCE}\"/g" "${PBS_HOME}/sched_priv/sched_config"
     fi
 
-    # Set up the queuejob hook
-    out=`qmgr -c "list hook" | grep "$QUEUEJOB_HOOK"`
+    # Set up the server hook
+    out=`qmgr -c "list hook" | grep "$SERVER_HOOK"`
     if [ -z "$out" ]; then
-        echo "Creating $QUEUEJOB_HOOK hook..."
-        qmgr -c "create hook $QUEUEJOB_HOOK" || exit 1
+        echo "Creating $SERVER_HOOK hook..."
+        qmgr -c "create hook $SERVER_HOOK" || exit 1
     else
-        echo "$QUEUEJOB_HOOK hook already exists"
+        echo "$SERVER_HOOK hook already exists"
     fi
-    echo "Importing and configuring queuejob hook..."
-    qmgr -c "import hook $QUEUEJOB_HOOK application/x-python default geopm_power_limit_server.py" || exit 1
-    qmgr -c "set hook $QUEUEJOB_HOOK event='queuejob'" || exit 1
+    echo "Importing and configuring server hook..."
+    qmgr -c "import hook $SERVER_HOOK application/x-python default $SERVER_HOOK.py" || exit 1
+    qmgr -c "set hook $SERVER_HOOK event='queuejob'" || exit 1
 
     echo "Done."
 }
 
 remove() {
-    if grep -q "^resources: .*$JOB_RESOURCE" "${PBS_HOME}/sched_priv/sched_config"; then
-            echo "Removing $JOB_RESOURCE from the list of consumable scheduler resources"
-            sed -i -e "s/^resources: \"\([^\"]\+\), ${JOB_RESOURCE}\(, [^\"]\+\)\?\"$/resources: \"\1\2\"/g" "${PBS_HOME}/sched_priv/sched_config"
+    if grep -q "^resources: .*$JOB_POWER_LIMIT_RESOURCE" "${PBS_HOME}/sched_priv/sched_config"; then
+            echo "Removing $JOB_POWER_LIMIT_RESOURCE from the list of consumable scheduler resources"
+            sed -i -e "s/^resources: \"\([^\"]\+\), ${JOB_POWER_LIMIT_RESOURCE}\(, [^\"]\+\)\?\"$/resources: \"\1\2\"/g" "${PBS_HOME}/sched_priv/sched_config"
     else
-            echo "$JOB_RESOURCE not found in the list of consumable scheduler resources"
+            echo "$JOB_POWER_LIMIT_RESOURCE not found in the list of consumable scheduler resources"
     fi
 
     # Remove resources
-    for resource in $NODE_RESOURCE $NODE_MAX_RESOURCE $NODE_MIN_RESOURCE $JOB_RESOURCE $DEFAULT_SLOWDOWN_RESOURCE $JOB_TYPE_RESOURCE
+    for resource in $POWER_LIMIT_RESOURCE $MAX_POWER_LIMIT_RESOURCE $MIN_POWER_LIMIT_RESOURCE $JOB_POWER_LIMIT_RESOURCE $DEFAULT_SLOWDOWN_RESOURCE $JOB_TYPE_RESOURCE
     do
         out=`qmgr -c "list resource" | grep "$resource"`
         if [ -z "$out" ]; then
@@ -100,13 +99,13 @@ remove() {
         fi
     done
 
-    # Remove the queuejob hook
-    out=`qmgr -c "list hook" | grep "$QUEUEJOB_HOOK"`
+    # Remove the server hook
+    out=`qmgr -c "list hook" | grep "$SERVER_HOOK"`
     if [ -z "$out" ]; then
-        echo "$QUEUEJOB_HOOK hook not found"
+        echo "$SERVER_HOOK hook not found"
     else
-        echo "Removing $QUEUEJOB_HOOK hook..."
-        qmgr -c "delete hook $QUEUEJOB_HOOK" || exit 1
+        echo "Removing $SERVER_HOOK hook..."
+        qmgr -c "delete hook $SERVER_HOOK" || exit 1
     fi
 
     echo "Done."
@@ -117,11 +116,11 @@ if [ $# -eq 0 ]; then
     echo "$SCHED_CONFIG_MODIFIED_MESSAGE"
     echo ""
     echo "GEOPM PBS server hook has been installed but is not yet configured."
-    echo "To set a power limit across jobs, set resources_available for $JOB_RESOURCE"
-    echo "To set a minimum node power limit, use $NODE_MIN_RESOURCE"
-    echo "To set a maximum node power limit, use $NODE_MAX_RESOURCE"
+    echo "To set a power limit across jobs, set resources_available for $JOB_POWER_LIMIT_RESOURCE"
+    echo "To set a minimum node power limit, use $MIN_POWER_LIMIT_RESOURCE"
+    echo "To set a maximum node power limit, use $MAX_POWER_LIMIT_RESOURCE"
     echo "To set a default job slowdown target, use $DEFAULT_SLOWDOWN_RESOURCE"
-    echo "Example to set a power limit: qmgr -c 'set server resources_available.${JOB_RESOURCE}=<max sum of node power (W)>'"
+    echo "Example to set a power limit: qmgr -c 'set server resources_available.${JOB_POWER_LIMIT_RESOURCE}=<max sum of node power (W)>'"
 elif [ $# -eq 1 ]; then
     if [ "$1" == "$REMOVE_OPT" ]; then
         remove

--- a/integration/service/open_pbs/geopm_install_pbs_power_limit_server.sh
+++ b/integration/service/open_pbs/geopm_install_pbs_power_limit_server.sh
@@ -3,16 +3,15 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 
+# Resources needed for the server
 NODE_RESOURCE="geopm-node-power-limit"
 NODE_MAX_RESOURCE="geopm-max-node-power-limit"
 NODE_MIN_RESOURCE="geopm-min-node-power-limit"
 JOB_RESOURCE="geopm-job-power-limit"
 JOB_TYPE_RESOURCE="geopm-job-type"
 DEFAULT_SLOWDOWN_RESOURCE="geopm-default-slowdown"
-NODE_CAP_HOOK="geopm_power_limit"
 QUEUEJOB_HOOK="geopm_power_limit_queuejob"
 REMOVE_OPT="--remove"
-SAVED_CONTROLS_BASE_DIR="/run/geopm/pbs-hooks"
 
 SCHED_CONFIG_MODIFIED_MESSAGE="\
 Note: ${PBS_HOME}/sched_priv/sched_config has been modified, but modifications
@@ -27,14 +26,14 @@ print_usage() {
     Usage: $0 [${REMOVE_OPT}]
 
     Invoking this script with no arguments installs the GEOPM power limit
-    hook.
+    server hook for queuejob events.
 
-    Use the --remove option to uninstall the hook. This will also remove the
-    $NODE_RESOURCE resource and the saved controls directory.
+    Use the --remove option to uninstall the hook and related resources.
     "
 }
 
 install() {
+    # Create all resources needed for the server side
     for resource in $NODE_RESOURCE $NODE_MAX_RESOURCE $NODE_MIN_RESOURCE $JOB_RESOURCE $DEFAULT_SLOWDOWN_RESOURCE
     do
         out=`qmgr -c "list resource" | grep "$resource"`
@@ -66,17 +65,7 @@ install() {
             sed -i -e "s/^resources: \"\([^\"]\+\)\"$/resources: \"\1, ${JOB_RESOURCE}\"/g" "${PBS_HOME}/sched_priv/sched_config"
     fi
 
-    out=`qmgr -c "list hook" | grep "$NODE_CAP_HOOK"`
-    if [ -z "$out" ]; then
-        echo "Creating $NODE_CAP_HOOK hook..."
-        qmgr -c "create hook $NODE_CAP_HOOK" || exit 1
-    else
-        echo "$NODE_CAP_HOOK hook already exists"
-    fi
-    echo "Importing and configuring prologue/epilogue hook..."
-    qmgr -c "import hook $NODE_CAP_HOOK application/x-python default geopm_power_limit_compute.py" || exit 1
-    qmgr -c "set hook $NODE_CAP_HOOK event='execjob_prologue,execjob_epilogue'" || exit 1
-
+    # Set up the queuejob hook
     out=`qmgr -c "list hook" | grep "$QUEUEJOB_HOOK"`
     if [ -z "$out" ]; then
         echo "Creating $QUEUEJOB_HOOK hook..."
@@ -99,6 +88,7 @@ remove() {
             echo "$JOB_RESOURCE not found in the list of consumable scheduler resources"
     fi
 
+    # Remove resources
     for resource in $NODE_RESOURCE $NODE_MAX_RESOURCE $NODE_MIN_RESOURCE $JOB_RESOURCE $DEFAULT_SLOWDOWN_RESOURCE $JOB_TYPE_RESOURCE
     do
         out=`qmgr -c "list resource" | grep "$resource"`
@@ -110,14 +100,7 @@ remove() {
         fi
     done
 
-    out=`qmgr -c "list hook" | grep "$NODE_CAP_HOOK"`
-    if [ -z "$out" ]; then
-        echo "$NODE_CAP_HOOK hook not found"
-    else
-        echo "Removing $NODE_CAP_HOOK hook..."
-        qmgr -c "delete hook $NODE_CAP_HOOK" || exit 1
-    fi
-
+    # Remove the queuejob hook
     out=`qmgr -c "list hook" | grep "$QUEUEJOB_HOOK"`
     if [ -z "$out" ]; then
         echo "$QUEUEJOB_HOOK hook not found"
@@ -126,8 +109,6 @@ remove() {
         qmgr -c "delete hook $QUEUEJOB_HOOK" || exit 1
     fi
 
-    rm -rf "$SAVED_CONTROLS_BASE_DIR"
-
     echo "Done."
 }
 
@@ -135,9 +116,7 @@ if [ $# -eq 0 ]; then
     install
     echo "$SCHED_CONFIG_MODIFIED_MESSAGE"
     echo ""
-    echo "GEOPM PBS plugins have been installed but are not yet configured."
-    echo "The prologue/epilogue hook ($NODE_CAP_HOOK) needs to be installed on all compute nodes."
-    echo "The queuejob hook ($QUEUEJOB_HOOK) needs to be installed on the PBS server."
+    echo "GEOPM PBS server hook has been installed but is not yet configured."
     echo "To set a power limit across jobs, set resources_available for $JOB_RESOURCE"
     echo "To set a minimum node power limit, use $NODE_MIN_RESOURCE"
     echo "To set a maximum node power limit, use $NODE_MAX_RESOURCE"

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -319,7 +319,9 @@ def load_resources(event, job_id):
 
 
 def do_power_limit_prologue(event):
+    pbs.logmsg(pbs.LOG_DEBUG, f"Entering prologue")
     job_id = event.job.id
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Job ID: {job_id}")
 
     if os.path.exists(_SAVED_CONTROLS_FILE):
         restore_controls_from_file(event, _SAVED_CONTROLS_FILE)
@@ -396,6 +398,7 @@ def do_power_limit_prologue(event):
 
 
 def do_power_limit_epilogue(event):
+    pbs.logmsg(pbs.LOG_DEBUG, f"Entering epilogue")
     if os.path.exists(_SAVED_CONTROLS_FILE):
         restore_controls_from_file(event, _SAVED_CONTROLS_FILE)
     event.accept()

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -59,6 +59,21 @@ _controls = [
     ]
 
 
+def print_env():
+    pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING: GEOPM hook: Printing environment variables...")
+    env = []
+    for k, v in os.environ.items():
+        env.append(f"{k}={v}")
+    pbs.logmsg(pbs.LOG_DEBUG, "DEBUGGING: GEOPM hook:  " + "\n".join(env))
+
+    path = []
+    for k in sys.path:
+        path.append(f"{k}")
+    pbs.logmsg(pbs.LOG_DEBUG, "DEBUGGING: GEOPM hook:  " + "\n".join(path))
+
+    pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING: GEOPM hook:  geopmdpy location: {pio.__file__}" )
+
+
 def clip_list(list_to_clip, min_value, max_value):
     """Clip each element in a list.
     """
@@ -335,6 +350,7 @@ def do_power_limit_prologue(event):
         restore_controls_from_file(event, _SAVED_CONTROLS_FILE)
 
     resource_dict = load_resources(event, job_id)
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Loaded resources: {resource_dict}")
 
     node_power_limit_str = resource_dict.get(_POWER_LIMIT_RESOURCE)
     if node_power_limit_str is not None:
@@ -415,6 +431,7 @@ def do_power_limit_epilogue(event):
 
 def hook_main():
     try:
+        print_env()
         event = pbs.event()
         event_type = event.type
         if event_type == pbs.EXECJOB_PROLOGUE:

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -152,21 +152,24 @@ def allocate_budget_to_nodes(budget, max_node_power, x0, A, B, C):
     return slowdown, power_by_node
 
 
-def get_model_from_config(hook_config, job_type, per_host=False):
+def get_model_from_config(hook_config, job_type, per_host=False, event=None):
     if hook_config is None or job_type is None:
         return None
 
     if 'profiles' not in hook_config:
-        pbs.logmsg(pbs.LOG_WARNING, 'Missing profiles section in the GEOPM PBS config')
+        if event is not None:
+            pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: Missing profiles section in the GEOPM PBS config")
         return None
 
     model_max_power = hook_config.get("max_power", None)
     if model_max_power is None:
-        pbs.logmsg(pbs.LOG_WARNING, 'Missing max_power in the GEOPM PBS config')
+        if event is not None:
+            pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: Missing max_power in the GEOPM PBS config")
         return None
 
     if job_type not in hook_config['profiles']:
-        pbs.logmsg(pbs.LOG_WARNING, f'Requested job type {job_type} has no performance model in the GEOPM PBS config')
+        if event is not None:
+            pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: Requested job type {job_type} has no performance model in the GEOPM PBS config")
         return None
 
     profile = hook_config['profiles'][job_type]
@@ -189,7 +192,8 @@ def get_model_from_config(hook_config, job_type, per_host=False):
             B = float(model_coefficients['B'])
             C = float(model_coefficients['C'])
         except:
-            pbs.logmsg(pbs.LOG_WARNING, f'Invalid coefficients for profile {job_type} in GEOPM PBS config')
+            if event is not None:
+                pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: Invalid coefficients for profile {job_type} in GEOPM PBS config")
             return None
 
         return {
@@ -201,7 +205,7 @@ def get_model_from_config(hook_config, job_type, per_host=False):
         }
 
 
-def predict_power_cap_at_performance_factor(job_type, slowdown, min_power_per_node, max_power_per_node):
+def predict_power_cap_at_performance_factor(job_type, slowdown, min_power_per_node, max_power_per_node, event=None):
     """Predict the node power cap needed to achieve a target slowdown for a
     given job type. If job_type is None or is not configured, this function
     assumes a 1:1 linear mapping between power and performance (half power
@@ -213,7 +217,7 @@ def predict_power_cap_at_performance_factor(job_type, slowdown, min_power_per_no
         with open(pbs.hook_config_filename) as f:
             hook_config = json.load(f)
 
-    model = get_model_from_config(hook_config, job_type)
+    model = get_model_from_config(hook_config, job_type, event=event)
     do_use_model = model is not None
 
     if do_use_model:
@@ -222,7 +226,8 @@ def predict_power_cap_at_performance_factor(job_type, slowdown, min_power_per_no
             # Solve for the positive root (less than 100% of max power) at '-slowdown' offset:
             result = model['max_power'] * (model['x0'] - (-model['B'] + math.sqrt(model['B']**2 - 4 * model['A'] * (model['C'] - slowdown))) / (2 * model['A']))
         except Exception as e:
-            pbs.logmsg(pbs.LOG_WARNING, f'Unable to estimate job power. {str(e)}')
+            if event is not None:
+                pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: Unable to estimate job power. {str(e)}")
             do_use_model = False
 
     if not do_use_model:
@@ -319,7 +324,7 @@ def load_resources(event, job_id):
 
 
 def do_power_limit_prologue(event):
-    pbs.logmsg(pbs.LOG_DEBUG, f"Entering prologue")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Entering prologue")
     job_id = event.job.id
     pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Job ID: {job_id}")
 
@@ -360,7 +365,7 @@ def do_power_limit_prologue(event):
         use_uniform_limit = True
         if hook_config is not None and 'node_profile_name' in hook_config:
             job_type = hook_config['node_profile_name']
-            host_models = get_model_from_config(hook_config, job_type, per_host=True)
+            host_models = get_model_from_config(hook_config, job_type, per_host=True, event=event)
             if host_models is not None:
                 max_node_power = host_models['max_power']
                 try:
@@ -369,7 +374,7 @@ def do_power_limit_prologue(event):
                     B = [host_models[host]['B'] for host in vnode_names]
                     C = [host_models[host]['C'] for host in vnode_names]
                 except (ValueError, KeyError):
-                    pbs.logmsg(pbs.LOG_WARNING, 'GEOPM PBS config has an incomplete set of host models. Using uniform power limits.')
+                    pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: GEOPM PBS config has an incomplete set of host models. Using uniform power limits.")
                 else:
                     use_uniform_limit = False
                     slowdown, power_by_node = allocate_budget_to_nodes(
@@ -398,7 +403,7 @@ def do_power_limit_prologue(event):
 
 
 def do_power_limit_epilogue(event):
-    pbs.logmsg(pbs.LOG_DEBUG, f"Entering epilogue")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Entering epilogue")
     if os.path.exists(_SAVED_CONTROLS_FILE):
         restore_controls_from_file(event, _SAVED_CONTROLS_FILE)
     event.accept()

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -238,11 +238,14 @@ def predict_power_cap_at_performance_factor(job_type, slowdown, min_power_per_no
 
 
 def read_controls(event, controls):
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: In read_controls()...")
     try:
         for c in controls:
+            pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Reading signal {c['name']}...")
             c["setting"] = pio.read_signal(c["name"], c["domain_type"],
                                            c["domain_idx"])
     except RuntimeError as e:
+        pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: Unable to read signal {c['name']}: {e}")
         reject_event(event, f"Unable to read signal {c['name']}: {e}")
 
 

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -402,6 +402,7 @@ def do_power_limit_prologue(event):
     _power_limit_control["setting"] = power_limit
     pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to write new power limit settings")
     write_controls(event, _controls)
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to accept job")
     event.accept()
 
 

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -26,6 +26,8 @@ import pbs
 from geopmdpy import pio
 from geopmdpy import system_files
 
+os.environ["ZES_ENABLE_SYSMAN"] = "1"
+os.environ["ZE_FLAT_DEVICE_HIERARCHY"] = "COMPOSITE"
 
 _SAVED_CONTROLS_PATH = "/run/geopm/pbs-hooks/SAVE_FILES"
 _SAVED_CONTROLS_FILE = _SAVED_CONTROLS_PATH + "/power-limit-save-control.json"

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -23,8 +23,8 @@ import copy
 import math
 
 import pbs
+import subprocess # nosec
 
-from geopmdpy import pio
 from geopmdpy import system_files
 
 os.environ["ZES_ENABLE_SYSMAN"] = "1"
@@ -251,13 +251,21 @@ def predict_power_cap_at_performance_factor(job_type, slowdown, min_power_per_no
 
     return min(max(min_power_per_node, result), max_power_per_node)
 
+def pio_read_signal(name, domain, domain_idx):
+    pid = subprocess.run(['geopmread', name, str(domain), str(domain_idx)],
+                         check=True, text=True, capture_output=True)
+    return float(pid.stdout)
+
+def pio_write_control(name, domain, domain_idx, setting):
+    subprocess.run(['geopmwrite', name, str(domain), str(domain_idx), str(setting)],
+                   check=True)
 
 def read_controls(event, controls):
     pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: In read_controls()...")
     try:
         for c in controls:
             pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Reading signal {c['name']}...")
-            c["setting"] = pio.read_signal(c["name"], c["domain_type"],
+            c["setting"] = pio_read_signal(c["name"], c["domain_type"],
                                            c["domain_idx"])
     except RuntimeError as e:
         pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: Unable to read signal {c['name']}: {e}")
@@ -267,7 +275,7 @@ def read_controls(event, controls):
 def write_controls(event, controls):
     try:
         for c in controls:
-            pio.write_control(c["name"], c["domain_type"], c["domain_idx"],
+            pio_write_control(c["name"], c["domain_type"], c["domain_idx"],
                               c["setting"])
     except RuntimeError as e:
         reject_event(event, f"Unable to write control {c['name']}: {e}")

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -294,6 +294,9 @@ def do_power_limit_prologue():
     job_id = e.job.id
     server_job = pbs.server().job(job_id)
 
+    if os.path.exists(_SAVED_CONTROLS_FILE):
+        restore_controls_from_file(_SAVED_CONTROLS_FILE)
+
     node_power_limit_requested = False
     try:
         node_power_limit_str = server_job.Resource_List[_POWER_LIMIT_RESOURCE]
@@ -309,8 +312,6 @@ def do_power_limit_prologue():
         pass
 
     if not node_power_limit_requested and not job_power_limit_requested:
-        if os.path.exists(_SAVED_CONTROLS_FILE):
-            restore_controls_from_file(_SAVED_CONTROLS_FILE)
         e.accept()
         return
 
@@ -376,7 +377,7 @@ def hook_main():
         elif event_type == pbs.EXECJOB_EPILOGUE:
             do_power_limit_epilogue()
         else:
-            reject_event("Power limit hook incorrectly configured!")
+            reject_event("Power limit compute hook incorrectly configured!")
     except SystemExit:
         pass
     except:

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -30,12 +30,7 @@ from geopmdpy import system_files
 _SAVED_CONTROLS_PATH = "/run/geopm/pbs-hooks/SAVE_FILES"
 _SAVED_CONTROLS_FILE = _SAVED_CONTROLS_PATH + "/power-limit-save-control.json"
 _POWER_LIMIT_RESOURCE = "geopm-node-power-limit"
-_MAX_POWER_LIMIT_RESOURCE = "geopm-max-node-power-limit"
-_MIN_POWER_LIMIT_RESOURCE = "geopm-min-node-power-limit"
 _JOB_POWER_LIMIT_RESOURCE = "geopm-job-power-limit"
-_DEFAULT_SLOWDOWN_RESOURCE = "geopm-default-slowdown"
-_JOB_TYPE_RESOURCE = "geopm-job-type"
-_DEFAULT_SLOWDOWN = 0.0
 
 _power_limit_control = {
         "name": "MSR::PLATFORM_POWER_LIMIT:PL1_POWER_LIMIT",

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -383,10 +383,14 @@ def do_power_limit_prologue(event):
 
     pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Requested power limit: {power_limit}")
     current_settings = copy.deepcopy(_controls)
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to read current power limit settings")
     read_controls(event, current_settings)
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to make save directory: {_SAVED_CONTROLS_PATH}")
     system_files.secure_make_dirs(_SAVED_CONTROLS_PATH)
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to save current power limit settings to: {_SAVED_CONTROLS_FILE}")
     save_controls_to_file(event, _SAVED_CONTROLS_FILE, current_settings)
     _power_limit_control["setting"] = power_limit
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to write new power limit settings")
     write_controls(event, _controls)
     event.accept()
 

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -3,7 +3,7 @@
 #
 # This file contains the prologue and epilogue hooks for GEOPM power limiting
 # functionality in PBS environments. It should be installed on compute nodes.
-# The queuejob functionality is in a separate file (geopm_power_limit_server.py)
+# The server/queuejob functionality is in a separate file (geopm_power_limit_server.py)
 # which should be installed on the PBS server.
 
 import sys

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -7,6 +7,7 @@
 # which should be installed on the PBS server.
 
 import sys
+import glob
 
 PYTHON_PATHS = [
         "/usr/lib/python3.6/site-packages",
@@ -29,6 +30,7 @@ from geopmdpy import system_files
 os.environ["ZES_ENABLE_SYSMAN"] = "1"
 os.environ["ZE_FLAT_DEVICE_HIERARCHY"] = "COMPOSITE"
 
+_RESOURCE_FILE_SEARCH_PATH = "/var/tmp"
 _SAVED_CONTROLS_PATH = "/run/geopm/pbs-hooks/SAVE_FILES"
 _SAVED_CONTROLS_FILE = _SAVED_CONTROLS_PATH + "/power-limit-save-control.json"
 _POWER_LIMIT_RESOURCE = "geopm-node-power-limit"
@@ -230,103 +232,129 @@ def predict_power_cap_at_performance_factor(job_type, slowdown, min_power_per_no
     return min(max(min_power_per_node, result), max_power_per_node)
 
 
-def read_controls(controls):
+def read_controls(event, controls):
     try:
         for c in controls:
             c["setting"] = pio.read_signal(c["name"], c["domain_type"],
                                            c["domain_idx"])
     except RuntimeError as e:
-        reject_event(f"Unable to read signal {c['name']}: {e}")
+        reject_event(event, f"Unable to read signal {c['name']}: {e}")
 
 
-def write_controls(controls):
+def write_controls(event, controls):
     try:
         for c in controls:
             pio.write_control(c["name"], c["domain_type"], c["domain_idx"],
                               c["setting"])
     except RuntimeError as e:
-        reject_event(f"Unable to write control {c['name']}: {e}")
+        reject_event(event, f"Unable to write control {c['name']}: {e}")
 
 
-def resource_to_float(resource_name, resource_str):
+def resource_to_float(event, resource_name, resource_str):
     try:
         value = float(resource_str)
         return value
     except ValueError:
-        reject_event(f"Invalid value provided for: {resource_name}")
+        reject_event(event, f"Invalid value provided for: {resource_name}")
 
 
-def save_controls_to_file(file_name, controls):
+def save_controls_to_file(event, file_name, controls):
     try:
         with open(file_name, "w") as f:
             f.write(json.dumps(controls))
     except (OSError, ValueError) as e:
-        reject_event(f"Unable to write to saved controls file: {e}")
+        reject_event(event, f"Unable to write to saved controls file: {e}")
 
 
-def reject_event(msg):
-    e = pbs.event()
-    if e.type in [pbs.EXECJOB_PROLOGUE, pbs.EXECJOB_EPILOGUE]:
-        e.job.delete()
-    e.reject(f"{e.hook_name}: {msg}")
+def reject_event(event, msg):
+    if event.type in [pbs.EXECJOB_PROLOGUE, pbs.EXECJOB_EPILOGUE]:
+        event.job.delete()
+    event.reject(f"{event.hook_name}: {msg}")
 
 
-def restore_controls_from_file(file_name):
+def restore_controls_from_file(event, file_name):
     controls_json = None
     try:
         with open(file_name) as f:
             controls_json = f.read()
     except (OSError, ValueError) as e:
-        reject_event(f"Unable to read saved controls file: {e}")
+        reject_event(event, f"Unable to read saved controls file: {e}")
 
     try:
         controls = json.loads(controls_json)
         if not controls:
-            reject_event("Encountered empty saved controls file")
-        write_controls(controls)
+            reject_event(event, "Encountered empty saved controls file")
+        write_controls(event, controls)
     except (json.decoder.JSONDecodeError, KeyError, TypeError) as e:
-        reject_event(f"Malformed saved controls file: {e}")
+        reject_event(event, f"Malformed saved controls file: {e}")
     os.unlink(file_name)
 
 
-def do_power_limit_prologue():
-    e = pbs.event()
-    job_id = e.job.id
-    server_job = pbs.server().job(job_id)
+def parse_resource_file(event, path):
+    result = {}
+    if not path:
+        return result
+    try:
+        with open(path) as f:
+            data = f.read()
+        for pair in data.split(';'):
+            pair = pair.strip()
+            if not pair:
+                continue
+            if '=' in pair:
+                k, v = pair.split('=', 1)
+                result[k.strip()] = v.strip()
+    except FileNotFoundError as e:
+        reject_event(event, f"logue resources file not found: {e}")
+    return result
+
+
+def load_resources(event, job_id):
+    prefix = str(job_id)
+    pattern = os.path.join(_RESOURCE_FILE_SEARCH_PATH, f"{prefix}*.resources")
+    matches = glob.glob(pattern)
+    name =  matches[0] if matches else None
+
+    return parse_resource_file(event, name)
+
+
+def do_power_limit_prologue(event):
+    job_id = event.job.id
 
     if os.path.exists(_SAVED_CONTROLS_FILE):
-        restore_controls_from_file(_SAVED_CONTROLS_FILE)
+        restore_controls_from_file(event, _SAVED_CONTROLS_FILE)
 
-    node_power_limit_requested = False
-    try:
-        node_power_limit_str = server_job.Resource_List[_POWER_LIMIT_RESOURCE]
-        node_power_limit_requested = bool(node_power_limit_str)
-    except KeyError:
-        pass
+    resource_dict = load_resources(event, job_id)
 
-    job_power_limit_requested = False
-    try:
-        job_power_limit_str = server_job.Resource_List[_JOB_POWER_LIMIT_RESOURCE]
-        job_power_limit_requested = bool(job_power_limit_str)
-    except KeyError:
-        pass
+    node_power_limit_str = resource_dict.get(_POWER_LIMIT_RESOURCE)
+    if node_power_limit_str is not None:
+        node_power_limit = resource_to_float(event, _POWER_LIMIT_RESOURCE, node_power_limit_str)
+        node_power_limit_requested = (node_power_limit > 0)
+    else:
+        node_power_limit_requested = False
+
+    job_power_limit_str = resource_dict.get(_JOB_POWER_LIMIT_RESOURCE)
+    if job_power_limit_str is not None:
+        job_power_limit = resource_to_float(event, _JOB_POWER_LIMIT_RESOURCE, job_power_limit_str)
+        job_power_limit_requested = (job_power_limit > 0)
+    else:
+        job_power_limit_requested = False
 
     if not node_power_limit_requested and not job_power_limit_requested:
-        e.accept()
+        event.accept()
         return
 
     if node_power_limit_requested:
         # The user requested a specific node power limit. Do not modify it.
-        power_limit = resource_to_float(_POWER_LIMIT_RESOURCE, node_power_limit_str)
+        power_limit = node_power_limit
     elif job_power_limit_requested:
         # A job power limit has been requested without a specific node power limit.
         # Let's use the node power models to distribute the job power limit.
-        job_power_limit = resource_to_float(_JOB_POWER_LIMIT_RESOURCE, job_power_limit_str)
         hook_config = None
         if pbs.hook_config_filename is not None:
             with open(pbs.hook_config_filename) as f:
                 hook_config = json.load(f)
-        vnode_names = [v.name for v in e.vnode_list.values()]
+        vnode_names = [v.name for v in event.vnode_list.values()]
         use_uniform_limit = True
         if hook_config is not None and 'node_profile_name' in hook_config:
             job_type = hook_config['node_profile_name']
@@ -338,7 +366,7 @@ def do_power_limit_prologue():
                     A = [host_models[host]['A'] for host in vnode_names]
                     B = [host_models[host]['B'] for host in vnode_names]
                     C = [host_models[host]['C'] for host in vnode_names]
-                except ValueError:
+                except (ValueError, KeyError):
                     pbs.logmsg(pbs.LOG_WARNING, 'GEOPM PBS config has an incomplete set of host models. Using uniform power limits.')
                 else:
                     use_uniform_limit = False
@@ -353,37 +381,41 @@ def do_power_limit_prologue():
             job_node_count = len(vnode_names)
             power_limit = job_power_limit / job_node_count
 
-    pbs.logmsg(pbs.LOG_DEBUG, f"{e.hook_name}: Requested power limit: {power_limit}")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Requested power limit: {power_limit}")
     current_settings = copy.deepcopy(_controls)
-    read_controls(current_settings)
+    read_controls(event, current_settings)
     system_files.secure_make_dirs(_SAVED_CONTROLS_PATH)
-    save_controls_to_file(_SAVED_CONTROLS_FILE, current_settings)
+    save_controls_to_file(event, _SAVED_CONTROLS_FILE, current_settings)
     _power_limit_control["setting"] = power_limit
-    write_controls(_controls)
-    e.accept()
+    write_controls(event, _controls)
+    event.accept()
 
 
-def do_power_limit_epilogue():
-    e = pbs.event()
+def do_power_limit_epilogue(event):
     if os.path.exists(_SAVED_CONTROLS_FILE):
-        restore_controls_from_file(_SAVED_CONTROLS_FILE)
-    e.accept()
+        restore_controls_from_file(event, _SAVED_CONTROLS_FILE)
+    event.accept()
+
 
 def hook_main():
     try:
-        event_type = pbs.event().type
+        event = pbs.event()
+        event_type = event.type
         if event_type == pbs.EXECJOB_PROLOGUE:
-            do_power_limit_prologue()
+            do_power_limit_prologue(event)
         elif event_type == pbs.EXECJOB_EPILOGUE:
-            do_power_limit_epilogue()
+            do_power_limit_epilogue(event)
         else:
-            reject_event("Power limit compute hook incorrectly configured!")
+            reject_event(event, "Power limit compute hook incorrectly configured!")
     except SystemExit:
         pass
     except:
         _, e, _ = sys.exc_info()
-        reject_event(f"Unexpected error: {str(e)}")
-
+        try:
+            event = event if 'event' in locals() else pbs.event()
+            reject_event(event, f"Unexpected error: {str(e)}")
+        except:
+            pass
 
 # Begin hook...
 hook_main()

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -1,7 +1,10 @@
 #  Copyright (c) 2015 - 2025 Intel Corporation
 #  SPDX-License-Identifier: BSD-3-Clause
 #
-
+# This file contains the prologue and epilogue hooks for GEOPM power limiting
+# functionality in PBS environments. It should be installed on compute nodes.
+# The queuejob functionality is in a separate file (geopm_power_limit_server.py)
+# which should be installed on the PBS server.
 
 import sys
 
@@ -368,93 +371,6 @@ def do_power_limit_epilogue():
         restore_controls_from_file(_SAVED_CONTROLS_FILE)
     e.accept()
 
-
-def do_power_limit_queuejob():
-    """GEOPM handler for queuejob PBS events. This handler sets a preliminary
-    job power resource request on a queued job so that the scheduler knows
-    the minimum amount of power needed by the job.
-    """
-    server = pbs.server()
-
-    requested_resources = pbs.event().job.Resource_List
-    submitted_node_limit = requested_resources[_POWER_LIMIT_RESOURCE]
-    submitted_job_limit = requested_resources[_JOB_POWER_LIMIT_RESOURCE]
-    max_power_in_pbs_server = server.resources_available[_JOB_POWER_LIMIT_RESOURCE]
-    if max_power_in_pbs_server is None:
-        # No high-level power limit is set. Nothing to do here.
-        pbs.event().accept()
-        return
-
-    min_power_per_node = server.resources_available[_MIN_POWER_LIMIT_RESOURCE]
-    if min_power_per_node is None:
-        pbs.event().reject(f'{_MIN_POWER_LIMIT_RESOURCE} must be configured.')
-
-    max_power_per_node = server.resources_available[_MAX_POWER_LIMIT_RESOURCE]
-    if max_power_per_node is None:
-        pbs.event().reject(f'{_MAX_POWER_LIMIT_RESOURCE} must be configured.')
-
-    min_power_per_node = float(min_power_per_node)
-    max_power_per_node = float(max_power_per_node)
-    max_power_in_pbs_server = float(max_power_in_pbs_server)
-
-    if (max_power_in_pbs_server is None
-            and submitted_node_limit is None
-            and submitted_job_limit is None):
-        # No limit has been specified by the admin or by the user, so we have
-        # nothing to do here.
-        return
-
-    # No nodes have been assigned to this job yet since it is still queued. We
-    # need to base our power request on how many PBS chunks were requested.
-    # Note: the user is allowed to change the request until just before the
-    # runjob event.
-    # TODO: Also need to do the same thing on modifyjob events?
-    node_count = 0
-    select = repr(requested_resources['select'])
-    for chunk in select.split('+'):
-        nchunks = 1
-        for c in chunk.split(':'):
-            kv = c.split('=')
-            if len(kv) == 1:
-                nchunks = int(kv[0])
-        node_count += nchunks
-
-    pbs.logmsg(pbs.LOG_DEBUG, f'submitted node limit: {submitted_node_limit}, '
-                              f'job limit: {submitted_job_limit}, nodes: {node_count}, '
-                              f'min power per node: {min_power_per_node}')
-
-    # This hook is meant to influence the scheduler's job-power-driven
-    # decisions, so we do not set node limit here (we do that in runjob).
-    job_power_limit = max(
-        min_power_per_node * node_count,
-        (submitted_job_limit or 0),
-        (submitted_node_limit or 0) * node_count)
-    if submitted_job_limit is None and submitted_node_limit is None:
-        # If the user is willing to accept some slowdown and didn't request a
-        # specific power limit, then set a power cap that is modeled to cause
-        # the allowed slowdown.
-
-        job_type = requested_resources[_JOB_TYPE_RESOURCE]
-        slowdown = float(requested_resources[_DEFAULT_SLOWDOWN_RESOURCE]) if requested_resources[_DEFAULT_SLOWDOWN_RESOURCE] is not None else _DEFAULT_SLOWDOWN
-        if slowdown < 0:
-            pbs.event().reject(f'{_DEFAULT_SLOWDOWN_RESOURCE} must be at least 0. Requested value: {slowdown}')
-            return
-
-        job_min_limit = predict_power_cap_at_performance_factor(
-                job_type, slowdown, min_power_per_node, max_power_per_node) * node_count
-        pbs.logmsg(pbs.LOG_DEBUG, f'job_min_limit = {job_min_limit}')
-        job_power_limit = max(job_power_limit, job_min_limit)
-
-    job_power_limit = min(job_power_limit,
-                          max_power_per_node * node_count)
-    if max_power_in_pbs_server is not None:
-        # By default, cap the power low enough that it won't be
-        # stuck waiting for more resources than are in the server.
-        job_power_limit = min(job_power_limit, max_power_in_pbs_server)
-
-    requested_resources[_JOB_POWER_LIMIT_RESOURCE] = job_power_limit
-
-
 def hook_main():
     try:
         event_type = pbs.event().type
@@ -462,8 +378,6 @@ def hook_main():
             do_power_limit_prologue()
         elif event_type == pbs.EXECJOB_EPILOGUE:
             do_power_limit_epilogue()
-        elif event_type == pbs.QUEUEJOB:
-            do_power_limit_queuejob()
         else:
             reject_event("Power limit hook incorrectly configured!")
     except SystemExit:

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -24,6 +24,7 @@ import math
 
 import pbs
 import subprocess # nosec
+import signal
 
 from geopmdpy import system_files
 
@@ -265,11 +266,13 @@ def pio_write_control(name, domain, domain_idx, setting):
 
 def read_controls(event, controls):
     pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: In read_controls()...")
-    cmd = "/usr/bin/python3 -c 'from dasbus.connection import SystemMessageBus; SystemMessageBus().get_proxy(\"io.github.geopm\",\"/io/github/geopm\").TopoGetCache()'"
-    try:
-        subprocess.run(cmd, shell=True, check=True)
-    except subprocess.CalledProcessError as e:
-        pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: {hostname}: Unable to create topo cache: {e}")
+    # Unblock SIGCHLD temporarily (hook env may have it blocked); restore after all reads.
+    old_mask = signal.pthread_sigmask(signal.SIG_BLOCK, [])  # Query current mask (no change)
+    did_unblock = False
+    if signal.SIGCHLD in old_mask:
+        signal.pthread_sigmask(signal.SIG_UNBLOCK, [signal.SIGCHLD])
+        did_unblock = True
+        pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: Unblocked SIGCHLD for geopmread operations")
     try:
         for c in controls:
             pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: Reading signal {c['name']}...")
@@ -278,7 +281,10 @@ def read_controls(event, controls):
     except RuntimeError as e:
         pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: {hostname}: Unable to read signal {c['name']}: {e}")
         reject_event(event, f"Unable to read signal {c['name']}: {e}")
-
+    finally:
+        if did_unblock:
+            signal.pthread_sigmask(signal.SIG_SETMASK, old_mask)
+            pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: Restored original signal mask after reading controls")
 
 def write_controls(event, controls):
     try:

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -27,6 +27,9 @@ import subprocess # nosec
 
 from geopmdpy import system_files
 
+import socket
+hostname = socket.gethostname()
+
 os.environ["ZES_ENABLE_SYSMAN"] = "1"
 os.environ["ZE_FLAT_DEVICE_HIERARCHY"] = "COMPOSITE"
 
@@ -60,18 +63,18 @@ _controls = [
 
 
 def print_env():
-    pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING: GEOPM hook: Printing environment variables...")
+    pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING {hostname}: GEOPM hook: Printing environment variables...")
     env = []
     for k, v in os.environ.items():
         env.append(f"{k}={v}")
-    pbs.logmsg(pbs.LOG_DEBUG, "DEBUGGING: GEOPM hook:  " + "\n".join(env))
+    pbs.logmsg(pbs.LOG_DEBUG, "DEBUGGING {hostname}: GEOPM hook:  " + "\n".join(env))
 
     path = []
     for k in sys.path:
         path.append(f"{k}")
-    pbs.logmsg(pbs.LOG_DEBUG, "DEBUGGING: GEOPM hook:  " + "\n".join(path))
+    pbs.logmsg(pbs.LOG_DEBUG, "DEBUGGING {hostname}: GEOPM hook:  " + "\n".join(path))
 
-    pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING: GEOPM hook:  geopmdpy location: {system_files.__file__}" )
+    pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING {hostname}: GEOPM hook:  geopmdpy location: {system_files.__file__}" )
 
 
 def clip_list(list_to_clip, min_value, max_value):
@@ -261,14 +264,14 @@ def pio_write_control(name, domain, domain_idx, setting):
                    check=True)
 
 def read_controls(event, controls):
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: In read_controls()...")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: In read_controls()...")
     try:
         for c in controls:
-            pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Reading signal {c['name']}...")
+            pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: Reading signal {c['name']}...")
             c["setting"] = pio_read_signal(c["name"], c["domain_type"],
                                            c["domain_idx"])
     except RuntimeError as e:
-        pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: Unable to read signal {c['name']}: {e}")
+        pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: {hostname}: Unable to read signal {c['name']}: {e}")
         reject_event(event, f"Unable to read signal {c['name']}: {e}")
 
 
@@ -350,15 +353,15 @@ def load_resources(event, job_id):
 
 
 def do_power_limit_prologue(event):
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Entering prologue")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: Entering prologue")
     job_id = event.job.id
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Job ID: {job_id}")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: Job ID: {job_id}")
 
     if os.path.exists(_SAVED_CONTROLS_FILE):
         restore_controls_from_file(event, _SAVED_CONTROLS_FILE)
 
     resource_dict = load_resources(event, job_id)
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Loaded resources: {resource_dict}")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: Loaded resources: {resource_dict}")
 
     node_power_limit_str = resource_dict.get(_POWER_LIMIT_RESOURCE)
     if node_power_limit_str is not None:
@@ -401,7 +404,7 @@ def do_power_limit_prologue(event):
                     B = [host_models[host]['B'] for host in vnode_names]
                     C = [host_models[host]['C'] for host in vnode_names]
                 except (ValueError, KeyError):
-                    pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: GEOPM PBS config has an incomplete set of host models. Using uniform power limits.")
+                    pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: {hostname}: GEOPM PBS config has an incomplete set of host models. Using uniform power limits.")
                 else:
                     use_uniform_limit = False
                     slowdown, power_by_node = allocate_budget_to_nodes(
@@ -415,23 +418,23 @@ def do_power_limit_prologue(event):
             job_node_count = len(vnode_names)
             power_limit = job_power_limit / job_node_count
 
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Requested power limit: {power_limit}")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: Requested power limit: {power_limit}")
     current_settings = copy.deepcopy(_controls)
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to read current power limit settings")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: About to read current power limit settings")
     read_controls(event, current_settings)
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to make save directory: {_SAVED_CONTROLS_PATH}")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: About to make save directory: {_SAVED_CONTROLS_PATH}")
     system_files.secure_make_dirs(_SAVED_CONTROLS_PATH)
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to save current power limit settings to: {_SAVED_CONTROLS_FILE}")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: About to save current power limit settings to: {_SAVED_CONTROLS_FILE}")
     save_controls_to_file(event, _SAVED_CONTROLS_FILE, current_settings)
     _power_limit_control["setting"] = power_limit
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to write new power limit settings")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: About to write new power limit settings")
     write_controls(event, _controls)
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: About to accept job")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: About to accept job")
     event.accept()
 
 
 def do_power_limit_epilogue(event):
-    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: Entering epilogue")
+    pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: Entering epilogue")
     if os.path.exists(_SAVED_CONTROLS_FILE):
         restore_controls_from_file(event, _SAVED_CONTROLS_FILE)
     event.accept()

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -265,9 +265,8 @@ def pio_write_control(name, domain, domain_idx, setting):
 
 def read_controls(event, controls):
     pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: In read_controls()...")
+    cmd = "/usr/bin/python3 -c 'from dasbus.connection import SystemMessageBus; SystemMessageBus().get_proxy(\"io.github.geopm\",\"/io/github/geopm\").TopoGetCache()'"
     try:
-        cmd = "/usr/bin/python3 -c 'from dasbus.connection import SystemMessageBus;"
-              "SystemMessageBus().get_proxy(\"io.github.geopm\",\"/io/github/geopm\").TopoGetCache()'"
         subprocess.run(cmd, shell=True, check=True)
     except subprocess.CalledProcessError as e:
         pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: {hostname}: Unable to create topo cache: {e}")

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -67,12 +67,12 @@ def print_env():
     env = []
     for k, v in os.environ.items():
         env.append(f"{k}={v}")
-    pbs.logmsg(pbs.LOG_DEBUG, "DEBUGGING {hostname}: GEOPM hook:  " + "\n".join(env))
+    pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING {hostname}: GEOPM hook:  " + "\n".join(env))
 
     path = []
     for k in sys.path:
         path.append(f"{k}")
-    pbs.logmsg(pbs.LOG_DEBUG, "DEBUGGING {hostname}: GEOPM hook:  " + "\n".join(path))
+    pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING {hostname}: GEOPM hook:  " + "\n".join(path))
 
     pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING {hostname}: GEOPM hook:  geopmdpy location: {system_files.__file__}" )
 

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -71,7 +71,7 @@ def print_env():
         path.append(f"{k}")
     pbs.logmsg(pbs.LOG_DEBUG, "DEBUGGING: GEOPM hook:  " + "\n".join(path))
 
-    pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING: GEOPM hook:  geopmdpy location: {pio.__file__}" )
+    pbs.logmsg(pbs.LOG_DEBUG, f"DEBUGGING: GEOPM hook:  geopmdpy location: {system_files.__file__}" )
 
 
 def clip_list(list_to_clip, min_value, max_value):

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -253,7 +253,7 @@ def predict_power_cap_at_performance_factor(job_type, slowdown, min_power_per_no
 
 def pio_read_signal(name, domain, domain_idx):
     pid = subprocess.run(['geopmread', name, str(domain), str(domain_idx)],
-                         check=True, text=True, capture_output=True)
+                         check=True, stdout=subprocess.PIPE, universal_newlines=True)
     return float(pid.stdout)
 
 def pio_write_control(name, domain, domain_idx, setting):

--- a/integration/service/open_pbs/geopm_power_limit_compute.py
+++ b/integration/service/open_pbs/geopm_power_limit_compute.py
@@ -266,6 +266,12 @@ def pio_write_control(name, domain, domain_idx, setting):
 def read_controls(event, controls):
     pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: In read_controls()...")
     try:
+        cmd = "/usr/bin/python3 -c 'from dasbus.connection import SystemMessageBus;"
+              "SystemMessageBus().get_proxy(\"io.github.geopm\",\"/io/github/geopm\").TopoGetCache()'"
+        subprocess.run(cmd, shell=True, check=True)
+    except subprocess.CalledProcessError as e:
+        pbs.logmsg(pbs.LOG_WARNING, f"{event.hook_name}: {hostname}: Unable to create topo cache: {e}")
+    try:
         for c in controls:
             pbs.logmsg(pbs.LOG_DEBUG, f"{event.hook_name}: {hostname}: Reading signal {c['name']}...")
             c["setting"] = pio_read_signal(c["name"], c["domain_type"],

--- a/integration/service/open_pbs/geopm_power_limit_server.py
+++ b/integration/service/open_pbs/geopm_power_limit_server.py
@@ -1,0 +1,221 @@
+#  Copyright (c) 2015 - 2025 Intel Corporation
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+# This file contains the queuejob hook for GEOPM power limiting functionality
+# in PBS environments. It should be installed on the PBS server.
+# The prologue and epilogue hooks are in a separate file (geopm_power_limit_compute.py)
+# which should be installed on compute nodes.
+
+import sys
+
+PYTHON_PATHS = [
+        "/usr/lib/python3.6/site-packages",
+        "/usr/lib64/python3.6/site-packages"]
+
+for p in PYTHON_PATHS:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import os
+import json
+import math
+
+import pbs
+
+
+_POWER_LIMIT_RESOURCE = "geopm-node-power-limit"
+_MAX_POWER_LIMIT_RESOURCE = "geopm-max-node-power-limit"
+_MIN_POWER_LIMIT_RESOURCE = "geopm-min-node-power-limit"
+_JOB_POWER_LIMIT_RESOURCE = "geopm-job-power-limit"
+_DEFAULT_SLOWDOWN_RESOURCE = "geopm-default-slowdown"
+_JOB_TYPE_RESOURCE = "geopm-job-type"
+_DEFAULT_SLOWDOWN = 0.0
+
+
+def reject_event(msg):
+    e = pbs.event()
+    e.reject(f"{e.hook_name}: {msg}")
+
+
+def get_model_from_config(hook_config, job_type, per_host=False):
+    if hook_config is None or job_type is None:
+        return None
+
+    if 'profiles' not in hook_config:
+        pbs.logmsg(pbs.LOG_WARNING, 'Missing profiles section in the GEOPM PBS config')
+        return None
+
+    model_max_power = hook_config.get("max_power", None)
+    if model_max_power is None:
+        pbs.logmsg(pbs.LOG_WARNING, 'Missing max_power in the GEOPM PBS config')
+        return None
+
+    if job_type not in hook_config['profiles']:
+        pbs.logmsg(pbs.LOG_WARNING, f'Requested job type {job_type} has no performance model in the GEOPM PBS config')
+        return None
+
+    profile = hook_config['profiles'][job_type]
+    if per_host:
+        if 'hosts' in profile:
+            models = dict(max_power = model_max_power)
+            for host_name, host_data in profile['hosts'].items():
+                model = host_data['model']
+                model['x0'] = float(model['x0'])
+                model['A'] = float(model['A'])
+                model['B'] = float(model['B'])
+                model['C'] = float(model['C'])
+                models[host_name] = model
+            return models
+    else:
+        model_coefficients = profile.get('model', dict())
+        try:
+            x0 = float(model_coefficients['x0'])
+            A = float(model_coefficients['A'])
+            B = float(model_coefficients['B'])
+            C = float(model_coefficients['C'])
+        except:
+            pbs.logmsg(pbs.LOG_WARNING, f'Invalid coefficients for profile {job_type} in GEOPM PBS config')
+            return None
+
+        return {
+            'max_power': model_max_power,
+            'x0': x0,
+            'A': A,
+            'B': B,
+            'C': C,
+        }
+
+
+def predict_power_cap_at_performance_factor(job_type, slowdown, min_power_per_node, max_power_per_node):
+    """Predict the node power cap needed to achieve a target slowdown for a
+    given job type. If job_type is None or is not configured, this function
+    assumes a 1:1 linear mapping between power and performance (half power
+    results in half performance). Slowdown of 0 means min time, slowdown of
+    1 means twice the min time (100% slowdown).
+    """
+    hook_config = None
+    if pbs.hook_config_filename is not None:
+        with open(pbs.hook_config_filename) as f:
+            hook_config = json.load(f)
+
+    model = get_model_from_config(hook_config, job_type)
+    do_use_model = model is not None
+
+    if do_use_model:
+        try:
+            # Using a quadratic model: slowdown = A * (x0 - percent_of_tdp)^2 + B * (x0 - percent_of_tdp) + C
+            # Solve for the positive root (less than 100% of max power) at '-slowdown' offset:
+            result = model['max_power'] * (model['x0'] - (-model['B'] + math.sqrt(model['B']**2 - 4 * model['A'] * (model['C'] - slowdown))) / (2 * model['A']))
+        except Exception as e:
+            pbs.logmsg(pbs.LOG_WARNING, f'Unable to estimate job power. {str(e)}')
+            do_use_model = False
+
+    if not do_use_model:
+        # Fallback case: Assume 1:1 linear mapping between power and performance
+        result = max_power_per_node / (slowdown + 1)
+
+    return min(max(min_power_per_node, result), max_power_per_node)
+
+
+def do_power_limit_queuejob():
+    """GEOPM handler for queuejob PBS events. This handler sets a preliminary
+    job power resource request on a queued job so that the scheduler knows
+    the minimum amount of power needed by the job.
+    """
+    server = pbs.server()
+
+    requested_resources = pbs.event().job.Resource_List
+    submitted_node_limit = requested_resources[_POWER_LIMIT_RESOURCE]
+    submitted_job_limit = requested_resources[_JOB_POWER_LIMIT_RESOURCE]
+    max_power_in_pbs_server = server.resources_available[_JOB_POWER_LIMIT_RESOURCE]
+    if max_power_in_pbs_server is None:
+        # No high-level power limit is set. Nothing to do here.
+        pbs.event().accept()
+        return
+
+    min_power_per_node = server.resources_available[_MIN_POWER_LIMIT_RESOURCE]
+    if min_power_per_node is None:
+        pbs.event().reject(f'{_MIN_POWER_LIMIT_RESOURCE} must be configured.')
+
+    max_power_per_node = server.resources_available[_MAX_POWER_LIMIT_RESOURCE]
+    if max_power_per_node is None:
+        pbs.event().reject(f'{_MAX_POWER_LIMIT_RESOURCE} must be configured.')
+
+    min_power_per_node = float(min_power_per_node)
+    max_power_per_node = float(max_power_per_node)
+    max_power_in_pbs_server = float(max_power_in_pbs_server)
+
+    if (max_power_in_pbs_server is None
+            and submitted_node_limit is None
+            and submitted_job_limit is None):
+        # No limit has been specified by the admin or by the user, so we have
+        # nothing to do here.
+        return
+
+    # No nodes have been assigned to this job yet since it is still queued. We
+    # need to base our power request on how many PBS chunks were requested.
+    # Note: the user is allowed to change the request until just before the
+    # runjob event.
+    # TODO: Also need to do the same thing on modifyjob events?
+    node_count = 0
+    select = repr(requested_resources['select'])
+    for chunk in select.split('+'):
+        nchunks = 1
+        for c in chunk.split(':'):
+            kv = c.split('=')
+            if len(kv) == 1:
+                nchunks = int(kv[0])
+        node_count += nchunks
+
+    pbs.logmsg(pbs.LOG_DEBUG, f'submitted node limit: {submitted_node_limit}, '
+                              f'job limit: {submitted_job_limit}, nodes: {node_count}, '
+                              f'min power per node: {min_power_per_node}')
+
+    # This hook is meant to influence the scheduler's job-power-driven
+    # decisions, so we do not set node limit here (we do that in runjob).
+    job_power_limit = max(
+        min_power_per_node * node_count,
+        (submitted_job_limit or 0),
+        (submitted_node_limit or 0) * node_count)
+    if submitted_job_limit is None and submitted_node_limit is None:
+        # If the user is willing to accept some slowdown and didn't request a
+        # specific power limit, then set a power cap that is modeled to cause
+        # the allowed slowdown.
+
+        job_type = requested_resources[_JOB_TYPE_RESOURCE]
+        slowdown = float(requested_resources[_DEFAULT_SLOWDOWN_RESOURCE]) if requested_resources[_DEFAULT_SLOWDOWN_RESOURCE] is not None else _DEFAULT_SLOWDOWN
+        if slowdown < 0:
+            pbs.event().reject(f'{_DEFAULT_SLOWDOWN_RESOURCE} must be at least 0. Requested value: {slowdown}')
+            return
+
+        job_min_limit = predict_power_cap_at_performance_factor(
+                job_type, slowdown, min_power_per_node, max_power_per_node) * node_count
+        pbs.logmsg(pbs.LOG_DEBUG, f'job_min_limit = {job_min_limit}')
+        job_power_limit = max(job_power_limit, job_min_limit)
+
+    job_power_limit = min(job_power_limit,
+                          max_power_per_node * node_count)
+    if max_power_in_pbs_server is not None:
+        # By default, cap the power low enough that it won't be
+        # stuck waiting for more resources than are in the server.
+        job_power_limit = min(job_power_limit, max_power_in_pbs_server)
+
+    requested_resources[_JOB_POWER_LIMIT_RESOURCE] = job_power_limit
+
+
+def hook_main():
+    try:
+        event_type = pbs.event().type
+        if event_type == pbs.QUEUEJOB:
+            do_power_limit_queuejob()
+        else:
+            reject_event("Power limit queuejob hook incorrectly configured!")
+    except SystemExit:
+        pass
+    except:
+        _, e, _ = sys.exc_info()
+        reject_event(f"Unexpected error: {str(e)}")
+
+
+# Begin hook...
+hook_main()

--- a/integration/service/open_pbs/geopm_power_limit_server.py
+++ b/integration/service/open_pbs/geopm_power_limit_server.py
@@ -1,7 +1,7 @@
 #  Copyright (c) 2015 - 2025 Intel Corporation
 #  SPDX-License-Identifier: BSD-3-Clause
 #
-# This file contains the queuejob hook for GEOPM power limiting functionality
+# This file contains the server hook for GEOPM power limiting functionality
 # in PBS environments. It should be installed on the PBS server.
 # The prologue and epilogue hooks are in a separate file (geopm_power_limit_compute.py)
 # which should be installed on compute nodes.
@@ -145,8 +145,8 @@ def do_power_limit_queuejob():
     max_power_in_pbs_server = float(max_power_in_pbs_server)
 
     if (max_power_in_pbs_server is None
-            and submitted_node_limit is None
-            and submitted_job_limit is None):
+        and submitted_node_limit is None
+        and submitted_job_limit is None):
         # No limit has been specified by the admin or by the user, so we have
         # nothing to do here.
         return

--- a/integration/service/open_pbs/geopm_power_limit_server.py
+++ b/integration/service/open_pbs/geopm_power_limit_server.py
@@ -31,7 +31,6 @@ _DEFAULT_SLOWDOWN_RESOURCE = "geopm-default-slowdown"
 _JOB_TYPE_RESOURCE = "geopm-job-type"
 _DEFAULT_SLOWDOWN = 0.0
 
-
 def reject_event(msg):
     e = pbs.event()
     e.reject(f"{e.hook_name}: {msg}")

--- a/integration/service/open_pbs/geopm_power_limit_server.py
+++ b/integration/service/open_pbs/geopm_power_limit_server.py
@@ -155,7 +155,6 @@ def do_power_limit_queuejob():
     # need to base our power request on how many PBS chunks were requested.
     # Note: the user is allowed to change the request until just before the
     # runjob event.
-    # TODO: Also need to do the same thing on modifyjob events?
     node_count = 0
     select = repr(requested_resources['select'])
     for chunk in select.split('+'):
@@ -201,14 +200,23 @@ def do_power_limit_queuejob():
 
     requested_resources[_JOB_POWER_LIMIT_RESOURCE] = job_power_limit
 
+def do_power_limit_modifyjob():
+    """GEOPM handler for modifyjob PBS events. This handler simply calls the
+    queue job handler to reevaluate the server-specified vs. user-specified
+    resources.
+    """
+    do_power_limit_queuejob()
+
 
 def hook_main():
     try:
         event_type = pbs.event().type
         if event_type == pbs.QUEUEJOB:
             do_power_limit_queuejob()
+        elif event_type == pbs.MODIFYJOB:
+            do_power_limit_modifyjob()
         else:
-            reject_event("Power limit queuejob hook incorrectly configured!")
+            reject_event("Power limit server hook incorrectly configured!")
     except SystemExit:
         pass
     except:

--- a/libgeopmd/src/LevelZeroGPUTopo.cpp
+++ b/libgeopmd/src/LevelZeroGPUTopo.cpp
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <string>
 #include <map>
+#include <fstream>
+#include <unistd.h>
 
 #include "geopm/Exception.hpp"
 #include "LevelZeroDevicePool.hpp"
@@ -98,10 +100,40 @@ namespace geopm
         return cpu_affinity_ideal(GEOPM_DOMAIN_GPU, gpu_idx);
     }
 
+    namespace {
+        std::ofstream &levelzero_topo_log()
+        {
+            static std::ofstream log_stream;
+            log_stream.rdbuf()->pubsetbuf(0, 0);
+            static bool initialized = false;
+            if (!initialized) {
+                char tmpl[] = "/tmp/geopm-levelzero-gpu-topo-log-XXXXXX";
+                int fd = mkstemp(tmpl);
+                if (fd != -1) {
+                    // We just needed the path; reopen with ofstream for convenience
+                    close(fd);
+                    log_stream.open(tmpl, std::ios_base::out | std::ios_base::app);
+                }
+                initialized = true;
+            }
+            return log_stream;
+        }
+        inline void lvlzero_log(const std::string &msg)
+        {
+            auto &ls = levelzero_topo_log();
+            if (ls.is_open()) {
+                ls << msg << std::endl;
+            }
+        }
+    }
+
     std::set<int> LevelZeroGPUTopo::cpu_affinity_ideal(int domain, int gpu_idx) const
     {
         std::set<int> result = {};
+        lvlzero_log("LevelZeroGPUTopo::cpu_affinity_ideal(domain=" +
+                    std::to_string(domain) + ", gpu_idx=" + std::to_string(gpu_idx) + ") called.");
         if (domain == GEOPM_DOMAIN_GPU) {
+            lvlzero_log("LevelZeroGPUTopo::cpu_affinity_ideal(): domain is GEOPM_DOMAIN_GPU");
             if (gpu_idx < 0 || (unsigned int)gpu_idx >= m_cpu_affinity_ideal.size()) {
                 throw Exception("LevelZeroGPUTopo::" + std::string(__func__) + ": gpu_idx " +
                                 std::to_string(gpu_idx) + " is out of range",
@@ -110,6 +142,7 @@ namespace geopm
             result = m_cpu_affinity_ideal.at(gpu_idx);
         }
         else if (domain == GEOPM_DOMAIN_GPU_CHIP) {
+            lvlzero_log("LevelZeroGPUTopo::cpu_affinity_ideal(): domain is GEOPM_DOMAIN_GPU_CHIP");
             if (gpu_idx < 0 || (unsigned int)gpu_idx >= m_cpu_affinity_ideal_chip.size()) {
                 throw Exception("LevelZeroGPUTopo::" + std::string(__func__) + ": gpu_idx " +
                                 std::to_string(gpu_idx) + " is out of range",
@@ -122,6 +155,8 @@ namespace geopm
                             std::to_string(domain) + " is not supported.",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
+        lvlzero_log("LevelZeroGPUTopo::cpu_affinity_ideal(): returning set of size " +
+                    std::to_string(result.size()));
         return result;
     }
 }

--- a/libgeopmd/src/MSRIOGroup.cpp
+++ b/libgeopmd/src/MSRIOGroup.cpp
@@ -901,6 +901,8 @@ namespace geopm
 
     double MSRIOGroup::read_signal(const std::string &signal_name, int domain_type, int domain_idx)
     {
+        std::cerr << "DEBUGGING libgeopmd: In MSRIOGroup()::read_signal() for signal_name=" << signal_name
+                  << ", domain_type=" << domain_type << ", domain_idx=" << domain_idx << std::endl;
         if (!is_valid_signal(signal_name)) {
             throw Exception("MSRIOGroup::read_signal(): signal name \"" +
                             signal_name + "\" not found",
@@ -915,6 +917,7 @@ namespace geopm
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
         }
         std::shared_ptr<Signal> ref_sig = m_signal_available.at(signal_name).signals[domain_idx];
+        std::cerr << "DEBUGGING libgeopmd: In PlatformIOImp()::read_signal(): About to read signal" << std::endl;
         return ref_sig->read();
     }
 

--- a/libgeopmd/src/PlatformIO.cpp
+++ b/libgeopmd/src/PlatformIO.cpp
@@ -6,6 +6,7 @@
 
 #include "PlatformIOImp.hpp"
 
+#include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
 #include <algorithm>
@@ -41,6 +42,7 @@ namespace geopm
 
     PlatformIO &platform_io(void)
     {
+        std::cerr << "DEBUGGING libgeopmd: In platform_io() singleton constructor..." << std::endl;
         return platform_io_helper(false);
     }
 
@@ -64,6 +66,7 @@ namespace geopm
         , m_iogroup_list(std::move(iogroup_list))
         , m_do_restore(false)
     {
+        std::cerr << "DEBUGGING libgeopmd: In PlatformIOImp() constructor..." << std::endl;
         if (m_iogroup_list.empty()) {
             for (const auto &it : IOGroup::iogroup_names()) {
                 try {
@@ -81,6 +84,7 @@ namespace geopm
                 }
             }
         }
+        std::cerr << "DEBUGGING libgeopmd: Completed PlatformIOImp() constructor" << std::endl;
     }
 
     void PlatformIOImp::register_iogroup(std::shared_ptr<IOGroup> iogroup)
@@ -564,6 +568,7 @@ namespace geopm
                                       int domain_type,
                                       int domain_idx)
     {
+        std::cerr << "DEBUGGING libgeopmd: In PlatformIOImp()::read_signal()..." << std::endl;
         if (domain_type < 0 || domain_type >= GEOPM_NUM_DOMAIN) {
             throw Exception("PlatformIOImp::read_signal(): domain_type is out of range",
                             GEOPM_ERROR_INVALID, __FILE__, __LINE__);
@@ -589,8 +594,10 @@ namespace geopm
             }
             else {
                 try {
+                    std::cerr << "DEBUGGING libgeopmd: In PlatformIOImp()::read_signal(): About to call IOGroup -> read_signal()..." << std::endl;
                     result = ii->read_signal(signal_name, domain_type, domain_idx);
                     is_read_successful = true;
+                    std::cerr << "DEBUGGING libgeopmd: In PlatformIOImp()::read_signal(): Completed IOGroup read_signal()" << std::endl;
                 }
                 catch (const geopm::Exception &ex) {
                     err_msg += std::string(ex.what()) + "\n";
@@ -952,6 +959,8 @@ extern "C" {
     {
         int err = 0;
         try {
+            fprintf(stderr, "DEBUGGING libgeopmd: In geopm_pio_read_signal for signal %s\n", signal_name);
+            fflush(stderr);
             *result = geopm::platform_io().read_signal(signal_name, domain_type, domain_idx);
         }
         catch (...) {

--- a/libgeopmd/src/PlatformTopo.cpp
+++ b/libgeopmd/src/PlatformTopo.cpp
@@ -55,6 +55,15 @@ static int geopm_topo_popen(const char *cmd, FILE **fid)
     int err = 0;
     *fid = NULL;
 
+    // Unblock SIGCHLD to ensure handler runs; prevents infinite loop if caller blocked it.
+    sigset_t old_sig_mask;
+    sigset_t sigchld_set;
+    sigemptyset(&sigchld_set);
+    sigaddset(&sigchld_set, SIGCHLD);
+    if (sigprocmask(SIG_UNBLOCK, &sigchld_set, &old_sig_mask) != 0) {
+        return errno ? errno : GEOPM_ERROR_RUNTIME;
+    }
+
     struct sigaction save_action;
     g_popen_complete_signal_action.sa_handler = geopm_topo_popen_complete;
     sigemptyset(&g_popen_complete_signal_action.sa_mask);
@@ -63,13 +72,20 @@ static int geopm_topo_popen(const char *cmd, FILE **fid)
     if (!err) {
         *fid = popen(cmd, "r");
         while (*fid && !g_is_popen_complete) {
-
+            // Waiting for SIGCHLD to set g_is_popen_complete
         }
         g_is_popen_complete = 0;
         sigaction(SIGCHLD, &save_action, NULL);
-        if (*fid == NULL) {
+        if (sigprocmask(SIG_SETMASK, &old_sig_mask, NULL) != 0) {
             err = errno ? errno : GEOPM_ERROR_RUNTIME;
         }
+        if (*fid == NULL && !err) {
+            err = errno ? errno : GEOPM_ERROR_RUNTIME;
+        }
+    }
+    else {
+        // Restore original mask if handler setup failed
+        sigprocmask(SIG_SETMASK, &old_sig_mask, NULL);
     }
     return err;
 }

--- a/libgeopmd/src/PlatformTopo.cpp
+++ b/libgeopmd/src/PlatformTopo.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 #include <stdexcept>
+#include <iostream>
 
 #include "geopm_sched.h"
 #include "geopm_time.h"
@@ -440,6 +441,25 @@ namespace geopm
 
     void PlatformTopoImp::create_cache(const std::string &cache_file_name, const GPUTopo &gtopo)
     {
+        // Create debug log file (template contains XXXXXX prior to mkstemp)
+        std::string log_template = "/tmp/geopm-topo-create-cache-log-XXXXXX";
+        char log_path[PATH_MAX];
+        log_path[PATH_MAX - 1] = '\0';
+        strncpy(log_path, log_template.c_str(), PATH_MAX - 1);
+        int log_fd = mkstemp(log_path);
+        std::ofstream log_stream;
+        log_stream.rdbuf()->pubsetbuf(0, 0);
+        if (log_fd != -1) {
+            // We only need std::ofstream; descriptor stays open until stream closes
+            log_stream.open(log_path, std::ios_base::out | std::ios_base::app);
+        }
+        auto log = [&](const std::string &msg) {
+            if (log_stream.is_open()) {
+                log_stream << msg << std::endl;
+            }
+        };
+
+        log("PlatformTopoImp::create_cache(\"" + cache_file_name + "\") called.");
         // If cache file is not present, or is too old, create it
         bool is_file_ok = false;
         try {
@@ -469,6 +489,8 @@ namespace geopm
             std::ostringstream cmd;
             cmd << "unset LD_PRELOAD; LC_ALL=C lscpu -x >> " << tmp_path << ";";
 
+            log(std::string("PlatformTopoImp::create_cache(): running command: ") + cmd.str());
+
             FILE *pid;
             int err = geopm_topo_popen(cmd.str().c_str(), &pid);
             if (err) {
@@ -481,34 +503,50 @@ namespace geopm
                 throw Exception("PlatformTopo::create_cache(): Could not pclose lscpu command: ",
                                 errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
             }
+
+            log("PlatformTopoImp::create_cache(): About to inspect GPU topology");
+
             if (gtopo.num_gpu() != 0) {
+                log("PlatformTopoImp::create_cache(): num_gpu is non-zero");
                 std::ofstream cache_stream;
                 cache_stream.open(tmp_path, std::ios_base::app);
+                log("PlatformTopoImp::create_cache(): opened tmp file for appending");
                 std::vector<int> gpu_domains = {
                     GEOPM_DOMAIN_GPU,
                     GEOPM_DOMAIN_GPU_CHIP
                 };
                 for (const auto &domain_type : gpu_domains) {
                     std::string short_name = gpu_short_name(domain_type);
+                    log("PlatformTopoImp::create_cache(): Inspecting " + short_name);
                     int num_domain = gtopo.num_gpu(domain_type);
+                    log("PlatformTopoImp::create_cache(): num_domain is " + std::to_string(num_domain));
                     for (int domain_idx = 0; domain_idx != num_domain; ++domain_idx) {
+                        log("PlatformTopoImp::create_cache(): Inspecting " + short_name + std::to_string(domain_idx));
                         cache_stream << "GPU " << short_name << domain_idx << " CPU(s):";
                         std::string delim = " ";
                         for (const auto &cpu_idx : gtopo.cpu_affinity_ideal(domain_type, domain_idx)) {
+                            log("PlatformTopoImp::create_cache():   CPU " + std::to_string(cpu_idx));
                             cache_stream << delim << cpu_idx;
                             delim = ",";
                         }
                         cache_stream << "\n";
                     }
+                    log("PlatformTopoImp::create_cache(): Finished inspecting " + short_name);
                 }
+                log("PlatformTopoImp::create_cache(): Finished inspecting GPUs");
                 cache_stream.close();
             }
+            log("PlatformTopoImp::create_cache(): About to rename tmp file");
             err = rename(tmp_path, cache_file_name.c_str());
+            log("PlatformTopoImp::create_cache(): Finished renaming tmp file");
             if (err) {
                 unlink(tmp_path);
                 throw Exception("PlatformTopo::create_cache(): Could not rename tmp_path: ",
                                 errno ? errno : GEOPM_ERROR_RUNTIME, __FILE__, __LINE__);
             }
+        }
+        if (log_stream.is_open()) {
+            log_stream.close(); // ensures flush & close
         }
     }
 


### PR DESCRIPTION
- Modify cache clean up code so that the cache is always present, not just on demand
- Adds work around to hook code that unblocks sigchld
- Add fix to libgeopmd that unblocks sigchld prior to calling popen()