### PR TITLE
Fix inconsistent signal name in `GPUActivityAgent`: `LEVELZERO::METRIC::XVE_STALL` vs `LEVELZERO::METRIC:XVE_STALL`

### DIFF
--- a/libgeopm/src/GPUActivityAgent.cpp
+++ b/libgeopm/src/GPUActivityAgent.cpp
@@ -100,7 +100,7 @@ namespace geopm
         signal_domains.push_back(m_platform_io.signal_domain_type("GPU_CORE_FREQUENCY_STATUS"));
         signal_domains.push_back(m_platform_io.signal_domain_type("GPU_CORE_ACTIVITY"));
         const auto ALL_NAMES = m_platform_io.signal_names();
-        if (ALL_NAMES.count("LEVELZERO::METRIC::XVE_STALL") != 0) {
+        if (ALL_NAMES.count("LEVELZERO::METRIC:XVE_STALL") != 0) {
             signal_domains.push_back(m_platform_io.signal_domain_type("LEVELZERO::METRIC:XVE_STALL"));
         }
         signal_domains.push_back(m_platform_io.signal_domain_type("GPU_UTILIZATION"));


### PR DESCRIPTION
In `GPUActivityAgent::init_platform_io()`, the existence check for the XVE stall signal uses a different string than the one used for the subsequent domain type query and signal push:

```cpp
// Line 103 — presence check uses double ::
if (ALL_NAMES.count("LEVELZERO::METRIC::XVE_STALL") != 0) {
    signal_domains.push_back(m_platform_io.signal_domain_type("LEVELZERO::METRIC:XVE_STALL"));
}

// Line 140 — push uses single :
if (ALL_NAMES.count("LEVELZERO::METRIC:XVE_STALL") != 0) {
```

The correct signal name is `LEVELZERO::METRIC:XVE_STALL` (single `:`), consistent with how all other `LEVELZERO::METRIC:*` signals are named (e.g. `LEVELZERO::METRIC:XVE_ACTIVE` in LevelZeroIOGroup.cpp).

**Impact:** Due to the typo, the domain type lookup at line 104 is reached only when `LEVELZERO::METRIC::XVE_STALL` (with double `::`) exists in the signal name set, which it never does. This means `XVE_STALL`'s domain is never included in `signal_domains`, potentially causing the agent to compute the wrong `m_agent_domain` on platforms where stall tracking is available.

**Fix:** Change line 103 from `"LEVELZERO::METRIC::XVE_STALL"` to `"LEVELZERO::METRIC:XVE_STALL"`.